### PR TITLE
cellular: add basic support to discover and instantiate Cellular modules

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
@@ -407,6 +407,7 @@ public abstract class AbstractXBeeDevice {
 		XBeeProtocol protocol = getXBeeProtocol();
 		if (protocol != XBeeProtocol.DIGI_MESH 
 				&& protocol != XBeeProtocol.DIGI_POINT
+				&& protocol != XBeeProtocol.CELLULAR
 				&& protocol != XBeeProtocol.UNKNOWN) {
 			response = getParameter("MY");
 			xbee16BitAddress = new XBee16BitAddress(response);

--- a/library/src/main/java/com/digi/xbee/api/DigiMeshDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/DigiMeshDevice.java
@@ -27,6 +27,7 @@ import com.digi.xbee.api.models.XBeeProtocol;
  * This class represents a local DigiMesh device.
  * 
  * @see XBeeDevice
+ * @see CellularDevice
  * @see DigiPointDevice
  * @see Raw802Device
  * @see ZigBeeDevice

--- a/library/src/main/java/com/digi/xbee/api/DigiPointDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/DigiPointDevice.java
@@ -28,6 +28,7 @@ import com.digi.xbee.api.models.XBeeProtocol;
  * This class represents a local DigiPoint device.
  * 
  * @see XBeeDevice
+ * @see CellularDevice
  * @see DigiMeshDevice
  * @see Raw802Device
  * @see ZigBeeDevice

--- a/library/src/main/java/com/digi/xbee/api/Raw802Device.java
+++ b/library/src/main/java/com/digi/xbee/api/Raw802Device.java
@@ -31,6 +31,7 @@ import com.digi.xbee.api.utils.HexUtils;
  * This class represents a local 802.15.4 device.
  * 
  * @see XBeeDevice
+ * @see CellularDevice
  * @see DigiMeshDevice
  * @see DigiPointDevice
  * @see ZigBeeDevice

--- a/library/src/main/java/com/digi/xbee/api/WLANDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/WLANDevice.java
@@ -1,0 +1,323 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import com.digi.xbee.api.connection.IConnectionInterface;
+import com.digi.xbee.api.connection.serial.SerialPortParameters;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.listeners.IDataReceiveListener;
+import com.digi.xbee.api.listeners.IIOSampleReceiveListener;
+import com.digi.xbee.api.models.IP32BitAddress;
+import com.digi.xbee.api.models.XBee16BitAddress;
+import com.digi.xbee.api.models.XBee64BitAddress;
+import com.digi.xbee.api.models.XBeeMessage;
+
+/**
+ * This class provides common functionality for XBee WLAN devices.
+ * 
+ * @see CellularDevice
+ */
+public class WLANDevice extends XBeeDevice {
+
+	// Constants
+	private static final String OPERATION_EXCEPTION = "Operation not supported in this module.";
+	
+	// Variables
+	protected IP32BitAddress ipAddress;
+	
+	/**
+	 * Class constructor. Instantiates a new {@code WLANDevice} object in 
+	 * the given port name and baud rate.
+	 * 
+	 * @param port Serial port name where WLAN device is attached to.
+	 * @param baudRate Serial port baud rate to communicate with the device. 
+	 *                 Other connection parameters will be set as default (8 
+	 *                 data bits, 1 stop bit, no parity, no flow control).
+	 * 
+	 * @throws IllegalArgumentException if {@code baudRate < 0}.
+	 * @throws NullPointerException if {@code port == null}.
+	 * 
+	 * @see #WLANDevice(IConnectionInterface)
+	 * @see #WLANDevice(String, SerialPortParameters)
+	 * @see #WLANDevice(String, int, int, int, int, int)
+	 */
+	protected WLANDevice(String port, int baudRate) {
+		this(XBee.createConnectiontionInterface(port, baudRate));
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new {@code WLANDevice} object in 
+	 * the given serial port name and settings.
+	 * 
+	 * @param port Serial port name where WLAN device is attached to.
+	 * @param baudRate Serial port baud rate to communicate with the device.
+	 * @param dataBits Serial port data bits.
+	 * @param stopBits Serial port data bits.
+	 * @param parity Serial port data bits.
+	 * @param flowControl Serial port data bits.
+	 * 
+	 * @throws IllegalArgumentException if {@code baudRate < 0} or
+	 *                                  if {@code dataBits < 0} or
+	 *                                  if {@code stopBits < 0} or
+	 *                                  if {@code parity < 0} or
+	 *                                  if {@code flowControl < 0}.
+	 * @throws NullPointerException if {@code port == null}.
+	 * 
+	 * @see #WLANDevice(IConnectionInterface)
+	 * @see #WLANDevice(String, int)
+	 * @see #WLANDevice(String, SerialPortParameters)
+	 */
+	protected WLANDevice(String port, int baudRate, int dataBits, int stopBits, int parity, int flowControl) {
+		this(port, new SerialPortParameters(baudRate, dataBits, stopBits, parity, flowControl));
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new {@code WLANDevice} object in 
+	 * the given serial port name and parameters.
+	 * 
+	 * @param port Serial port name where WLAN device is attached to.
+	 * @param serialPortParameters Object containing the serial port parameters.
+	 * 
+	 * @throws NullPointerException if {@code port == null} or
+	 *                              if {@code serialPortParameters == null}.
+	 * 
+	 * @see #WLANDevice(IConnectionInterface)
+	 * @see #WLANDevice(String, int)
+	 * @see #WLANDevice(String, int, int, int, int, int)
+	 * @see com.digi.xbee.api.connection.serial.SerialPortParameters
+	 */
+	protected WLANDevice(String port, SerialPortParameters serialPortParameters) {
+		this(XBee.createConnectiontionInterface(port, serialPortParameters));
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new {@code WLANDevice} object with 
+	 * the given connection interface.
+	 * 
+	 * @param connectionInterface The connection interface with the physical 
+	 *                            WLAN device.
+	 * 
+	 * @throws NullPointerException if {@code connectionInterface == null}
+	 * 
+	 * @see #WLANDevice(String, int)
+	 * @see #WLANDevice(String, SerialPortParameters)
+	 * @see #WLANDevice(String, int, int, int, int, int)
+	 * @see com.digi.xbee.api.connection.IConnectionInterface
+	 */
+	protected WLANDevice(IConnectionInterface connectionInterface) {
+		super(connectionInterface);
+	}
+	
+	
+	/**
+	 * @deprecated This protocol does not support the network functionality.
+	 */
+	@Override
+	public XBeeNetwork getNetwork() {
+		// WLAN modules do not have a network of devices.
+		return null;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see com.digi.xbee.api.AbstractXBeeDevice#readDeviceInfo()
+	 */
+	@Override
+	public void readDeviceInfo() throws TimeoutException, XBeeException {
+		super.readDeviceInfo();
+		
+		// Read the module's IP address.
+		byte[] response = getParameter("MY");
+		ipAddress = new IP32BitAddress(response);
+	}
+	
+	/**
+	 * Returns the IP address of this WLAN device.
+	 * 
+	 * <p>To refresh this value use the {@link #readDeviceInfo()} method.</p>
+	 * 
+	 * @return The IP address of this WLAN device.
+	 * 
+	 * @see com.digi.xbee.api.models.IP23BitAddress
+	 */
+	public IP32BitAddress getIPAddress() {
+		return ipAddress;
+	}
+	
+	/**
+	 * @deprecated This protocol does not have an associated 16-bit address.
+	 */
+	@Override
+	public XBee16BitAddress get16BitAddress() {
+		// WLAN modules do not have 16-bit address.
+		return null;
+	}
+	
+	/**
+	 * @deprecated This protocol does not have not have a destination address. 
+	 *             This method will raise an 
+	 *             {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public XBee64BitAddress getDestinationAddress() throws TimeoutException,
+			XBeeException {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated This protocol does not have not have a destination address. 
+	 *             This method will raise an 
+	 *             {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void setDestinationAddress(XBee64BitAddress xbee64BitAddress)
+			throws TimeoutException, XBeeException {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public byte[] getPANID() throws TimeoutException, XBeeException {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void setPANID(byte[] panID) throws TimeoutException, XBeeException {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void addDataListener(IDataReceiveListener listener) {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void removeDataListener(IDataReceiveListener listener) {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void addIOSampleListener(IIOSampleReceiveListener listener) {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void removeIOSampleListener(IIOSampleReceiveListener listener) {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public XBeeMessage readData() {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public XBeeMessage readData(int timeout) {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public XBeeMessage readDataFrom(RemoteXBeeDevice remoteXBeeDevice) {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public XBeeMessage readDataFrom(RemoteXBeeDevice remoteXBeeDevice,
+			int timeout) {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void sendBroadcastData(byte[] data) throws TimeoutException,
+			XBeeException {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void sendData(RemoteXBeeDevice remoteXBeeDevice, byte[] data)
+			throws TimeoutException, XBeeException {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/**
+	 * @deprecated Operation not supported in this protocol. This method will
+	 *             raise an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void sendDataAsync(RemoteXBeeDevice remoteXBeeDevice, byte[] data)
+			throws XBeeException {
+		// Not supported in WLAN modules.
+		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+}

--- a/library/src/main/java/com/digi/xbee/api/ZigBeeDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/ZigBeeDevice.java
@@ -34,6 +34,7 @@ import com.digi.xbee.api.utils.HexUtils;
  * This class represents a local ZigBee device.
  * 
  * @see XBeeDevice
+ * @see CellularDevice
  * @see DigiMeshDevice
  * @see DigiPointDevice
  * @see Raw802Device

--- a/library/src/main/java/com/digi/xbee/api/models/CellularAssociationIndicationStatus.java
+++ b/library/src/main/java/com/digi/xbee/api/models/CellularAssociationIndicationStatus.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import java.util.HashMap;
+
+import com.digi.xbee.api.utils.HexUtils;
+
+/**
+ * Enumerates the different association indication status for the Cellular 
+ * protocol.
+ */
+public enum CellularAssociationIndicationStatus {
+
+	// Enumeration entries
+	SUCCESSFULLY_CONNECTED(0x00, "Connected to the Internet."),
+	POWERED_UP(0x20, "Modem powered up and enumerated."),
+	IDENTIFIED(0x21, "Modem identified."),
+	REGISTERING(0x22, "Modem registering."),
+	REGISTERED(0x23, "Modem registered."),
+	SETUP_DEVICE(0xA0, "Setup modem device."),
+	SETUP_USB(0xC0, "Setup modem USB."),
+	POWERUP(0xE0, "Power up modem."),
+	REBOOTING(0xFB, "Rebooting modem."),
+	SHUTTING_DOWN(0xFC, "Shutting down modem."),
+	MANUFACTURING_STATE(0xFD, "Modem in manufacturing state."),
+	UNEXPECTED_STATE(0xFE, "Modem in unexpected state."),
+	POWERED_DOWN(0xFF, "Modem powered down.");
+	
+	// Variables
+	private final int value;
+	
+	private final String description;
+	
+	private final static HashMap<Integer, CellularAssociationIndicationStatus> lookupTable = new HashMap<Integer, CellularAssociationIndicationStatus>();
+	
+	static {
+		for (CellularAssociationIndicationStatus associationIndicationStatus:values())
+			lookupTable.put(associationIndicationStatus.getValue(), associationIndicationStatus);
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new 
+	 * {@code CellularAssociationIndicationStatus} enumeration entry with the 
+	 * given parameters.
+	 * 
+	 * @param value Cellular association indication status value.
+	 * @param description Cellular association indication status description.
+	 */
+	CellularAssociationIndicationStatus(int value, String description) {
+		this.value = value;
+		this.description = description;
+	}
+	
+	/**
+	 * Returns the Cellular association indication status value.
+	 * 
+	 * @return The Cellular association indication status value.
+	 */
+	public int getValue() {
+		return value;
+	}
+	
+	/**
+	 * Returns the Cellular association indication status description.
+	 * 
+	 * @return The Cellular association indication status description.
+	 */
+	public String getDescription() {
+		return description;
+	}
+	
+	/**
+	 * Returns the {@code CellularAssociationIndicationStatus} associated to 
+	 * the given value.
+	 * 
+	 * @param value Value of the Cellular association indication status to 
+	 *              retrieve.
+	 * 
+	 * @return The Cellular association indication status of the associated 
+	 *         value, {@code null} if it could not be found in the table.
+	 */
+	public static CellularAssociationIndicationStatus get(int value) {
+		return lookupTable.get(value);
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Enum#toString()
+	 */
+	@Override
+	public String toString() {
+		return HexUtils.byteToHexString((byte)value) + ": " + description;
+	}
+}

--- a/library/src/main/java/com/digi/xbee/api/models/HardwareVersionEnum.java
+++ b/library/src/main/java/com/digi/xbee/api/models/HardwareVersionEnum.java
@@ -73,7 +73,8 @@ public enum HardwareVersionEnum {
 	S2D_TH_PRO(0x34, "XBP24D: S2D TH PRO"),
 	S2D_TH_REG(0x35, "XB24D: S2D TH Reg"),
 	SX(0x3E, "SX"),
-	XTR(0x3F, "XTR");
+	XTR(0x3F, "XTR"),
+	CELLULAR(0x40, "CELLULAR");
 	
 	// Variables
 	private final int value;

--- a/library/src/main/java/com/digi/xbee/api/models/IP32BitAddress.java
+++ b/library/src/main/java/com/digi/xbee/api/models/IP32BitAddress.java
@@ -19,35 +19,40 @@ import java.util.regex.Pattern;
 /**
  * This class represents a 32-bit IP address used in some protocols where each
  * radio module has its own 32 bit IP address.
- *
+ * 
  * <p>This address is only applicable for:</p>
  * <ul>
  *   <li>Cellular</li>
  * </ul>
  */
 public class IP32BitAddress {
-
+	
 	// Constants
+	/**
+	 * Broadcast IP address (value: "255.255.255.255").
+	 */
+	public static final IP32BitAddress BROADCAST_ADDRESS = new IP32BitAddress("255.255.255.255");
+	
 	private static final String ERROR_IP_NULL = "IP address cannot be null.";
 	private static final String ERROR_IP_TOO_LONG = "IP address cannot be longer than 4 bytes.";
 	private static final String ERROR_IP_INVALID = "Invalid IP address.";
-
+	
 	private static final int HASH_SEED = 23;
-
+	
 	public final static String IP_V4_PATTERN = "^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\."
 			+ "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\."
 			+ "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\."
 			+ "([01]?\\d\\d?|2[0-4]\\d|25[0-5])$";
-
+	
 	// Variables
 	private byte[] address;
-
+	
 	/**
-	 * Class constructor. Instantiates a new object of type
+	 * Class constructor. Instantiates a new object of type 
 	 * {@code IP32BitAddress} with the given parameters.
-	 *
+	 * 
 	 * @param address The 32 bit IP address as byte array.
-	 *
+	 * 
 	 * @throws IllegalArgumentException If {@code address.length > 4}.
 	 * @throws NullPointerException If {@code address == null}.
 	 */
@@ -56,16 +61,16 @@ public class IP32BitAddress {
 			throw new NullPointerException(ERROR_IP_NULL);
 		if (address.length > 4)
 			throw new IllegalArgumentException(ERROR_IP_TOO_LONG);
-
+		
 		generateIPAddress(address);
 	}
-
+	
 	/**
-	 * Class constructor. Instantiates a new object of type
+	 * Class constructor. Instantiates a new object of type 
 	 * {@code IP32BitAddress} with the given parameters.
-	 *
+	 * 
 	 * @param address The 32 bit IP address as integer array.
-	 *
+	 * 
 	 * @throws IllegalArgumentException If {@code address.length > 8}.
 	 * @throws NullPointerException If {@code address == null}.
 	 */
@@ -74,20 +79,20 @@ public class IP32BitAddress {
 			throw new NullPointerException(ERROR_IP_NULL);
 		if (address.length > 4)
 			throw new IllegalArgumentException(ERROR_IP_TOO_LONG);
-
+		
 		byte[] byteAddress = new byte[address.length];
 		for (int i = 0; i < address.length; i++)
 			byteAddress[i] = (byte)address[i];
-
+		
 		generateIPAddress(byteAddress);
 	}
-
+	
 	/**
-	 * Class constructor. Instantiates a new object of type
+	 * Class constructor. Instantiates a new object of type 
 	 * {@code IP32BitAddress} with the given parameters.
-	 *
+	 * 
 	 * @param address The 32 bit IP address as string.
-	 *
+	 * 
 	 * @throws IllegalArgumentException If the given address doesn't match the
 	 *                                  IP address pattern.
 	 * @throws NullPointerException If {@code address == null}.
@@ -95,50 +100,50 @@ public class IP32BitAddress {
 	public IP32BitAddress(String address) {
 		if (address == null)
 			throw new NullPointerException(ERROR_IP_NULL);
-
+		
 		Pattern p = Pattern.compile(IP_V4_PATTERN);
 		Matcher m = p.matcher(address);
 		if (!m.matches())
 			throw new IllegalArgumentException(ERROR_IP_INVALID);
-
+		
 		byte[] byteAddress = new byte[4];
-
+		
 		byteAddress[0] = (byte)Integer.parseInt(m.group(1));
 		byteAddress[1] = (byte)Integer.parseInt(m.group(2));
 		byteAddress[2] = (byte)Integer.parseInt(m.group(3));
 		byteAddress[3] = (byte)Integer.parseInt(m.group(4));
-
+		
 		generateIPAddress(byteAddress);
 	}
-
+	
 	/**
 	 * Generates and saves the IP byte address based on the given byte array.
-	 *
-	 * @param byteAddress The byte array used to generate the final IP byte
+	 * 
+	 * @param byteAddress The byte array used to generate the final IP byte 
 	 *                    address.
 	 */
 	private void generateIPAddress(byte[] byteAddress) {
 		this.address = new byte[4];
-
+		
 		int diff = 4 - byteAddress.length;
 		for (int i = 0; i < diff; i++)
 			this.address[i] = 0;
 		for (int i = diff; i < 4; i++)
 			this.address[i] = byteAddress[i - diff];
 	}
-
+	
 	/**
 	 * Retrieves the 32 bit IP address value as byte array.
-	 *
+	 * 
 	 * @return 32 bit IP address value as byte array.
 	 */
 	public byte[] getValue() {
 		return address;
 	}
-
+	
 	/**
 	 * Retrieves the 32 bit IP address value as string.
-	 *
+	 * 
 	 * @return 32 bit IP address value as string.
 	 */
 	public String getValueString() {
@@ -148,15 +153,14 @@ public class IP32BitAddress {
 				prettyIP += ".";
 			prettyIP += address[i] & 0xFF;
 		}
-
+		
 		return prettyIP;
 	}
-
+	
 	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
-	@Override
 	public boolean equals(Object obj) {
 		if (obj == null)
 			return false;
@@ -165,7 +169,7 @@ public class IP32BitAddress {
 		IP32BitAddress addr = (IP32BitAddress)obj;
 		return Arrays.equals(addr.getValue(), getValue());
 	}
-
+	
 	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
@@ -177,12 +181,11 @@ public class IP32BitAddress {
 			hash = hash * (hash + b);
 		return hash;
 	}
-
+	
 	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#toString()
 	 */
-	@Override
 	public String toString() {
 		return getValueString();
 	}

--- a/library/src/main/java/com/digi/xbee/api/models/XBeeIMEIAddress.java
+++ b/library/src/main/java/com/digi/xbee/api/models/XBeeIMEIAddress.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import java.util.regex.Pattern;
+
+import com.digi.xbee.api.utils.HexUtils;
+
+/**
+ * This class represents an IMEI address used by cellular devices.
+ * 
+ * <p>This address is only applicable for:</p>
+ * <ul>
+ *   <li>Cellular</li>
+ * </ul>
+ */
+public class XBeeIMEIAddress {
+
+	// Constants
+	private static final String ERROR_IMEI_NULL = "IMEI address cannot be null.";
+	private static final String ERROR_IMEI_TOO_LONG = "IMEI address cannot be longer than 8 bytes.";
+	private static final String ERROR_IMEI_INVALID = "Invalid IMEI address.";
+	
+	private static final int HASH_SEED = 23;
+	
+	private static final String IMEI_PATTERN = "^\\d{0,15}$";
+	
+	// Variables
+	private byte[] address;
+	
+	/**
+	 * Class constructor. Instantiates a new object of type 
+	 * {@code XBeeIMEIAddress} with the given parameter.
+	 * 
+	 * @param address The IMEI address as byte array.
+	 * 
+	 * @throws IllegalArgumentException If {@code address.length > 8}.
+	 * @throws NullPointerException If {@code address == null}.
+	 * 
+	 * @see #XBeeIMEIAddress(String)
+	 */
+	public XBeeIMEIAddress(byte[] address) {
+		if (address == null)
+			throw new NullPointerException(ERROR_IMEI_NULL);
+		if (address.length > 8)
+			throw new IllegalArgumentException(ERROR_IMEI_TOO_LONG);
+		
+		generateByteAddress(address);
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new object of type 
+	 * {@code XBeeIMEIAddress} with the given parameters.
+	 * 
+	 * @param address The IMEI address as string.
+	 * 
+	 * @throws IllegalArgumentException If the given address doesn't match the
+	 *                                  IMEI address pattern.
+	 * @throws NullPointerException If {@code address == null}.
+	 * 
+	 * @see #XBeeIMEIAddress(byte[])
+	 */
+	public XBeeIMEIAddress(String address) {
+		if (address == null)
+			throw new NullPointerException(ERROR_IMEI_NULL);
+		
+		if (!Pattern.matches(IMEI_PATTERN, address))
+			throw new IllegalArgumentException(ERROR_IMEI_INVALID);
+		
+		byte[] byteAddress = HexUtils.hexStringToByteArray(address);
+		
+		generateByteAddress(byteAddress);
+	}
+	
+	/**
+	 * Generates and saves the IMEI byte address based on the given byte array.
+	 * 
+	 * @param byteAddress The byte array used to generate the final IMEI byte 
+	 *                    address.
+	 */
+	private void generateByteAddress(byte[] byteAddress) {
+		this.address = new byte[8];
+		
+		int diff = 8 - byteAddress.length;
+		for (int i = 0; i < diff; i++)
+			this.address[i] = 0;
+		for (int i = diff; i < 8; i++)
+			this.address[i] = byteAddress[i - diff];
+	}
+	
+	/**
+	 * Retrieves the IMEI address value.
+	 * 
+	 * @return IMEI address value.
+	 */
+	public String getValue() {
+		return HexUtils.byteArrayToHexString(address).substring(1);
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null)
+			return false;
+		if (!(obj instanceof XBeeIMEIAddress))
+			return false;
+		XBeeIMEIAddress addr = (XBeeIMEIAddress)obj;
+		return addr.getValue().equals(getValue());
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		int hash = HASH_SEED;
+		for (byte b:getValue().getBytes())
+			hash = hash * (hash + b);
+		return hash;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return getValue();
+	}
+}

--- a/library/src/main/java/com/digi/xbee/api/models/XBeeProtocol.java
+++ b/library/src/main/java/com/digi/xbee/api/models/XBeeProtocol.java
@@ -35,6 +35,7 @@ public enum XBeeProtocol {
 	XLR_DM(12, "XLR"), // TODO [XLR_DM] XLR device with DigiMesh support.
 	SX(13, "XBee SX"),
 	XLR_MODULE(14, "XLR Module"),
+	CELLULAR(15, "Cellular"),
 	UNKNOWN(99, "Unknown");
 	
 	// Variables
@@ -218,6 +219,8 @@ public enum XBeeProtocol {
 		case S2D_TH_PRO:
 		case S2D_TH_REG:
 			return ZIGBEE;
+		case CELLULAR:
+			return CELLULAR;
 		default:
 			return ZIGBEE;
 		}

--- a/library/src/test/java/com/digi/xbee/api/CellularDeviceTest.java
+++ b/library/src/test/java/com/digi/xbee/api/CellularDeviceTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.models.CellularAssociationIndicationStatus;
+import com.digi.xbee.api.models.XBeeIMEIAddress;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CellularDevice.class, CellularAssociationIndicationStatus.class})
+public class CellularDeviceTest {
+	
+	// Constants.
+	private static final String PARAMETER_AI = "AI";
+	private static final byte[] RESPONSE_AI = new byte[]{0x00};
+	
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+	
+	// Variables.
+	private XBeeIMEIAddress imeiAddress;
+	
+	private CellularDevice cellularDevice;
+	
+	private CellularAssociationIndicationStatus validCellularAIStatus = CellularAssociationIndicationStatus.SUCCESSFULLY_CONNECTED;
+	
+	@Before
+	public void setup() throws Exception {
+		// Suppress the 'readDeviceInfo' method of the parent class so that it is not
+		// called from the child (CellularDevice) class.
+		PowerMockito.suppress(PowerMockito.method(WLANDevice.class, "readDeviceInfo"));
+		
+		// Spy the CellularDevice class.
+		SerialPortRxTx mockPort = Mockito.mock(SerialPortRxTx.class);
+		cellularDevice = PowerMockito.spy(new CellularDevice(mockPort));
+		
+		// Mock an IMEI address object.
+		imeiAddress = PowerMockito.mock(XBeeIMEIAddress.class);
+		
+		// Always return a valid Cellular association indication when requested.
+		PowerMockito.mockStatic(CellularAssociationIndicationStatus.class);
+		PowerMockito.when(CellularAssociationIndicationStatus.get(Mockito.anyInt())).thenReturn(validCellularAIStatus);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#getIMEIAddress()} and
+	 * {@link com.digi.xbee.api.CellularDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that the {@code readDeviceInfo()} method of the Cellular device generates 
+	 * the IMEI address correctly.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testReadDeviceInfoCellular() throws Exception {
+		// Whenever an XBeeIMEIAddress class is instantiated, the mocked IMEI address should be returned.
+		PowerMockito.whenNew(XBeeIMEIAddress.class).withAnyArguments().thenReturn(imeiAddress);
+		
+		// Fist, check that the IMEI is null (it has not been created yet)
+		assertNull(cellularDevice.getIMEIAddress());
+		
+		// Call the readDeviceInfo method.
+		cellularDevice.readDeviceInfo();
+		Mockito.verify((WLANDevice)cellularDevice, Mockito.times(1)).readDeviceInfo();
+		
+		// Verify that the IMEI address was generated.
+		assertEquals(imeiAddress, cellularDevice.getIMEIAddress());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#getADCValue(com.digi.xbee.api.io.IOLine)}, 
+	 * {@link com.digi.xbee.api.CellularDevice#getDIOChangeDetection()},
+	 * {@link com.digi.xbee.api.CellularDevice#setDIOChangeDetection(java.util.Set)}, 
+	 * {@link com.digi.xbee.api.CellularDevice#getDIOValue(com.digi.xbee.api.io.IOLine)}, 
+	 * {@link com.digi.xbee.api.CellularDevice#setDIOValue(com.digi.xbee.api.io.IOLine, com.digi.xbee.api.io.IOValue)},
+	 * {@link com.digi.xbee.api.CellularDevice#getIOConfiguration(com.digi.xbee.api.io.IOLine)},
+	 * {@link com.digi.xbee.api.CellularDevice#setIOConfiguration(com.digi.xbee.api.io.IOLine, com.digi.xbee.api.io.IOMode)},
+	 * {@link com.digi.xbee.api.CellularDevice#getIOSamplingRate()},
+	 * {@link com.digi.xbee.api.CellularDevice#setIOSamplingRate(int)},
+	 * {@link com.digi.xbee.api.CellularDevice#getNodeID()},
+	 * {@link com.digi.xbee.api.CellularDevice#setNodeID(String)},
+	 * {@link com.digi.xbee.api.CellularDevice#getPWMDutyCycle(com.digi.xbee.api.io.IOLine)},
+	 * {@link com.digi.xbee.api.CellularDevice#setPWMDutyCycle(com.digi.xbee.api.io.IOLine, double)} and
+	 * {@link com.digi.xbee.api.CellularDevice#readIOSample()}.
+	 * 
+	 * <p>Verify that the not supported methods of the Cellular protocol throw an
+	 * {@code UnsupportedOperationException}.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testNotSupportedOperations() throws Exception {
+		exception.expect(UnsupportedOperationException.class);
+		exception.expectMessage(is(equalTo("Operation not supported in Cellular protocol.")));
+		
+		// All the following operations should throw an 
+		// {@code UnsupportedOperationException} exception 
+		cellularDevice.getADCValue(null);
+		cellularDevice.getDIOChangeDetection();
+		cellularDevice.setDIOChangeDetection(null);
+		cellularDevice.getDIOValue(null);
+		cellularDevice.setDIOValue(null, null);
+		cellularDevice.getIOConfiguration(null);
+		cellularDevice.setIOConfiguration(null, null);
+		cellularDevice.getIOSamplingRate();
+		cellularDevice.setIOSamplingRate(-1);
+		cellularDevice.setNodeID(null);
+		cellularDevice.getPowerLevel();
+		cellularDevice.setPowerLevel(null);
+		cellularDevice.getPWMDutyCycle(null);
+		cellularDevice.setPWMDutyCycle(null, -1);
+		cellularDevice.readIOSample();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#get64BitAddress()} and
+	 * {@link com.digi.xbee.api.CellularDevice#getNodeID()},
+	 * 
+	 * <p>Verify that parameters not supported by the Cellular protocol are returned 
+	 * as {@code null}.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testNotSupportedParameters() throws Exception {
+		// Cellular devices do not have 64-bit address and Node ID.
+		assertNull(cellularDevice.get64BitAddress());
+		assertNull(cellularDevice.getNodeID());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#getCellularAssociationIndicationStatus()}.
+	 * 
+	 * <p>Check that the Cellular association indication method returns values 
+	 * successfully.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testAssociationIndicationStatus() throws Exception {
+		// Return a valid response when requesting the AI parameter value.
+		Mockito.doReturn(RESPONSE_AI).when(cellularDevice).getParameter(PARAMETER_AI);
+		
+		assertEquals(validCellularAIStatus, cellularDevice.getCellularAssociationIndicationStatus());
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/WLANDeviceTest.java
+++ b/library/src/test/java/com/digi/xbee/api/WLANDeviceTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.models.IP32BitAddress;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({WLANDevice.class})
+public class WLANDeviceTest {
+	
+	// Constants.
+	private static final String PARAMETER_MY = "MY";
+	private static final byte[] RESPONSE_MY = new byte[]{0x00, 0x00, 0x00, 0x00};
+	
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+	
+	// Variables.
+	private IP32BitAddress ipAddress;
+	
+	private WLANDevice wlanDevice;
+	
+	@Before
+	public void setup() throws Exception {
+		// Suppress the 'readDeviceInfo' method of the parent class so that it is not
+		// called from the child (WLANDevice) class.
+		PowerMockito.suppress(PowerMockito.method(AbstractXBeeDevice.class, "readDeviceInfo"));
+		
+		// Spy the WLANDevice class.
+		SerialPortRxTx mockPort = Mockito.mock(SerialPortRxTx.class);
+		wlanDevice = PowerMockito.spy(new WLANDevice(mockPort));
+		
+		// Mock an IP address object.
+		ipAddress = PowerMockito.mock(IP32BitAddress.class);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#getIPAddress()} and
+	 * {@link com.digi.xbee.api.WLANDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that the {@code readDeviceInfo()} method of the WLAN device generates 
+	 * the IP address correctly.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testReadDeviceInfoWLAN() throws Exception {
+		// Whenever an IP32BitAddress class is instantiated, the mocked IP address should be returned.
+		PowerMockito.whenNew(IP32BitAddress.class).withAnyArguments().thenReturn(ipAddress);
+		
+		// Return a valid response when requesting the MY parameter value.
+		Mockito.doReturn(RESPONSE_MY).when(wlanDevice).getParameter(PARAMETER_MY);
+		
+		// Fist, check that the IP is null (it has not been created yet)
+		assertNull(wlanDevice.getIPAddress());
+		
+		// Call the readDeviceInfo method.
+		wlanDevice.readDeviceInfo();
+		Mockito.verify((AbstractXBeeDevice)wlanDevice, Mockito.times(1)).readDeviceInfo();
+		
+		// Verify that the IP address was generated.
+		assertEquals(ipAddress, wlanDevice.getIPAddress());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#getDestinationAddress()},
+	 * {@link com.digi.xbee.api.WLANDevice#setDestinationAddress(com.digi.xbee.api.models.XBee64BitAddress)},
+	 * {@link com.digi.xbee.api.WLANDevice#getPANID()},
+	 * {@link com.digi.xbee.api.WLANDevice#setPANID(byte[])},
+	 * {@link com.digi.xbee.api.WLANDevice#addDataListener(com.digi.xbee.api.listeners.IDataReceiveListener)},
+	 * {@link com.digi.xbee.api.WLANDevice#removeDataListener(com.digi.xbee.api.listeners.IDataReceiveListener)},
+	 * {@link com.digi.xbee.api.WLANDevice#addIOSampleListener(com.digi.xbee.api.listeners.IIOSampleReceiveListener)},
+	 * {@link com.digi.xbee.api.WLANDevice#removeIOSampleListener(com.digi.xbee.api.listeners.IIOSampleReceiveListener)},
+	 * {@link com.digi.xbee.api.WLANDevice#readData()},
+	 * {@link com.digi.xbee.api.WLANDevice#readData(int)},
+	 * {@link com.digi.xbee.api.WLANDevice#readDataFrom(RemoteXBeeDevice)},
+	 * {@link com.digi.xbee.api.WLANDevice#readDataFrom(RemoteXBeeDevice, int)},
+	 * {@link com.digi.xbee.api.WLANDevice#sendBroadcastData(byte[])},
+	 * {@link com.digi.xbee.api.WLANDevice#sendData(RemoteXBeeDevice, byte[])} and
+	 * {@link com.digi.xbee.api.WLANDevice#sendDataAsync(RemoteXBeeDevice, byte[])}.
+	 * 
+	 * <p>Verify that the not supported methods of the WLAN device throw an
+	 * {@code UnsupportedOperationException}</p>.
+	 * 
+	 * @throws Exception
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testNotSupportedOperations() throws Exception {
+		exception.expect(UnsupportedOperationException.class);
+		exception.expectMessage(is(equalTo("Operation not supported in this module.")));
+		
+		// All the following operations should throw an 
+		// {@code UnsupportedOperationException} exception.
+		wlanDevice.getDestinationAddress();
+		wlanDevice.setDestinationAddress(null);
+		wlanDevice.getPANID();
+		wlanDevice.setPANID(null);
+		wlanDevice.addDataListener(null);
+		wlanDevice.removeDataListener(null);
+		wlanDevice.addIOSampleListener(null);
+		wlanDevice.removeIOSampleListener(null);
+		wlanDevice.readData();
+		wlanDevice.readData(-1);
+		wlanDevice.readDataFrom(null);
+		wlanDevice.readDataFrom(null, -1);
+		wlanDevice.sendBroadcastData(null);
+		wlanDevice.sendData((RemoteXBeeDevice)null, null);
+		wlanDevice.sendDataAsync((RemoteXBeeDevice)null, null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#get16BitAddress()} and
+	 * {@link com.digi.xbee.api.WLANDevice#getNetwork()}.
+	 * 
+	 * <p>Verify that parameters not supported by the WLAN device are returned 
+	 * as {@code null}.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testNotSupportedParameters() throws Exception {
+		// WLAN devices do not have 16-bit address and do not support the 
+		// network feature.
+		assertNull(wlanDevice.get16BitAddress());
+		assertNull(wlanDevice.getNetwork());
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/XBeeDeviceReadInfoTest.java
+++ b/library/src/test/java/com/digi/xbee/api/XBeeDeviceReadInfoTest.java
@@ -65,6 +65,7 @@ public class XBeeDeviceReadInfoTest {
 	private DigiPointDevice dpDevice;
 	private ZigBeeDevice zbDevice;
 	private Raw802Device r802Device;
+	private CellularDevice cellularDevice;
 	
 	@Before
 	public void setup() throws Exception {
@@ -76,6 +77,7 @@ public class XBeeDeviceReadInfoTest {
 		dpDevice = PowerMockito.spy(new DigiPointDevice(mockPort));
 		zbDevice = PowerMockito.spy(new ZigBeeDevice(mockPort));
 		r802Device = PowerMockito.spy(new Raw802Device(mockPort));
+		cellularDevice = PowerMockito.spy(new CellularDevice(mockPort));
 	}
 	
 	/**
@@ -571,6 +573,50 @@ public class XBeeDeviceReadInfoTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
 	 * 
+	 * <p>Verify that device info of a ZigBee local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidCellularClassForZBDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.ZIGBEE;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + cellularDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(cellularDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(cellularDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(cellularDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(cellularDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(cellularDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		cellularDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
 	 * <p>Verify that device info of a DigiPoint local device cannot be read if 
 	 * the class for the specified device is not the right one. It is, there is 
 	 * an AT command exception reading the parameter.</p>
@@ -698,6 +744,50 @@ public class XBeeDeviceReadInfoTest {
 		
 		// Execute the method under test.
 		r802Device.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a DigiPoint local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidCellularClassForDPDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.DIGI_POINT;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + cellularDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(cellularDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(cellularDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(cellularDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(cellularDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(cellularDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		cellularDevice.readDeviceInfo();
 	}
 	
 	/**
@@ -835,6 +925,50 @@ public class XBeeDeviceReadInfoTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
 	 * 
+	 * <p>Verify that device info of a 802.15.4 local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidCellularClassFor802Device() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.RAW_802_15_4;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + cellularDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(cellularDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(cellularDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(cellularDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(cellularDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(cellularDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		cellularDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
 	 * <p>Verify that device info of a DigiMesh local device cannot be read if 
 	 * the class for the specified device is not the right one. It is, there is 
 	 * an AT command exception reading the parameter.</p>
@@ -934,6 +1068,226 @@ public class XBeeDeviceReadInfoTest {
 	public void testReadDeviceInfoErrorInvalid802ClassForDMDevice() throws XBeeException, IOException {
 		// Setup the resources for the test.
 		XBeeProtocol realProtocol = XBeeProtocol.DIGI_MESH;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + r802Device.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(r802Device).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(r802Device).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(r802Device).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(r802Device).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(r802Device).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		r802Device.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a DigiMesh local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidCellularClassForDMDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.DIGI_MESH;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + cellularDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(cellularDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(cellularDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(cellularDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(cellularDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(cellularDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		cellularDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Cellular local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidDigiMeshClassForCellularDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.CELLULAR;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + dmDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(dmDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(dmDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(dmDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(dmDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(dmDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		dmDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Cellular local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidDigiPointClassForCellularDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.CELLULAR;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + dpDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(dpDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(dpDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(dpDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(dpDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(dpDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		dpDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Cellular local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidZigBeeClassForCellularDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.CELLULAR;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + zbDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(zbDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(zbDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(zbDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(zbDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(zbDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		zbDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Cellular local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalid802ClassForCellularDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.CELLULAR;
 		
 		exception.expect(XBeeException.class);
 		exception.expectMessage(is(equalTo("Error reading device information: "
@@ -1108,6 +1462,57 @@ public class XBeeDeviceReadInfoTest {
 		assertEquals(HardwareVersion.get(0x01), xbeeDevice.getHardwareVersion());
 		assertEquals("4567", xbeeDevice.getFirmwareVersion());
 		assertEquals(XBeeProtocol.DIGI_POINT, xbeeDevice.getXBeeProtocol());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a local device can be read successfully when the 
+	 * protocol of the device is Cellular. In this case the 64-bit and 16-bit addresses 
+	 * should be null, but the method should read valid values for the IP and IMEI
+	 * addresses.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException
+	 */
+	@Test
+	public void testReadDeviceInfoSuccessCellular() throws XBeeException, IOException {
+		// Return that the protocol of the device is first unknown and then DigiPoint when asked.
+		Mockito.when(xbeeDevice.getXBeeProtocol()).thenReturn(XBeeProtocol.UNKNOWN, XBeeProtocol.CELLULAR);
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(xbeeDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(xbeeDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(xbeeDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(xbeeDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(xbeeDevice).getParameter(PARAMETER_VR);
+		
+		// Return a valid response when requesting the MY parameter value.
+		Mockito.doReturn(RESPONSE_MY).when(xbeeDevice).getParameter(PARAMETER_MY);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(XBeeProtocol.DIGI_POINT);
+		
+		// Initialize the device.
+		xbeeDevice.readDeviceInfo();
+		
+		// Verify that all parameters but the network address were read successfully.
+		Mockito.verify(xbeeDevice, Mockito.times(2)).getXBeeProtocol();
+		Mockito.verify(xbeeDevice, Mockito.never()).getParameter(PARAMETER_MY);
+		assertEquals(XBee16BitAddress.UNKNOWN_ADDRESS, xbeeDevice.get16BitAddress());
+		assertEquals("XBEE", xbeeDevice.getNodeID());
+		assertEquals(HardwareVersion.get(0x01), xbeeDevice.getHardwareVersion());
+		assertEquals("4567", xbeeDevice.getFirmwareVersion());
+		assertEquals(XBeeProtocol.CELLULAR, xbeeDevice.getXBeeProtocol());
 	}
 	
 	/**

--- a/library/src/test/java/com/digi/xbee/api/models/CellularAssociationIndicationStatusTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/CellularAssociationIndicationStatusTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.digi.xbee.api.utils.HexUtils;
+
+public class CellularAssociationIndicationStatusTest {
+
+	// Variables.
+	private CellularAssociationIndicationStatus[] associationIndicationStatusValues;
+	
+	
+	@Before
+	public void setup() {
+		// Retrieve the list of enum. values.
+		associationIndicationStatusValues = CellularAssociationIndicationStatus.values();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.CellularAssociationIndicationStatus#getValue()}.
+	 * 
+	 * <p>Verify that the ID of each {@code CellularAssociationIndicationStatus} 
+	 * entry is valid.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusValues() {
+		for (CellularAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues)
+			assertTrue(associationIndicationStatus.getValue() >= 0);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.CellularAssociationIndicationStatus#name()}.
+	 * 
+	 * <p>Verify that the name of each {@code CellularAssociationIndicationStatus} 
+	 * entry is valid.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusNames() {
+		for (CellularAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues) {
+			assertNotNull(associationIndicationStatus.name());
+			assertTrue(associationIndicationStatus.name().length() > 0);
+		}
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.CellularAssociationIndicationStatus#getDescription()}.
+	 * 
+	 * <p>Verify that the description of each {@code CellularAssociationIndicationStatus} 
+	 * entry is valid.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusDescriptions() {
+		for (CellularAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues) {
+			assertNotNull(associationIndicationStatus.getDescription());
+			assertTrue(associationIndicationStatus.getDescription().length() > 0);
+		}
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.CellularAssociationIndicationStatus#get(int)}.
+	 * 
+	 * <p>Verify that each {@code CellularAssociationIndicationStatus} entry can be 
+	 * retrieved statically using its value.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusStaticAccess() {
+		for (CellularAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues)
+			assertEquals(associationIndicationStatus, CellularAssociationIndicationStatus.get(associationIndicationStatus.getValue()));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.CellularAssociationIndicationStatus#get(int)}.
+	 * 
+	 * <p>Verify that when trying to get an invalid {@code CellularAssociationIndicationStatus} 
+	 * entry, a {@code null} entry is retrieved.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusStaticInvalidAccess() {
+		assertNull(CellularAssociationIndicationStatus.get(0xAA));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.CellularAssociationIndicationStatus#toString()}.
+	 * 
+	 * <p>Verify that the {@code toString()} method of an {@code CellularAssociationIndicationStatus} 
+	 * entry returns its description correctly.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusToString() {
+		for (CellularAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues)
+			assertEquals(HexUtils.byteToHexString((byte)associationIndicationStatus.getValue()) + ": " + associationIndicationStatus.getDescription(), associationIndicationStatus.toString());
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/models/IP32BitAddressTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/IP32BitAddressTest.java
@@ -22,31 +22,31 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 public class IP32BitAddressTest {
-
+	
 	// Constants.
 	private final static byte[] INVALID_BYTE_ARRAY = new byte[]{0x01, 0x17, 0x7B, (byte)0xEA, 0x4B};
 	private final static int[] INVALID_INT_ARRAY = new int[]{1, 17, 123, 234, 345};
 	private final static String INVALID_STRING = "Hello world";
 	private final static String INVALID_STRING_2 = "1.580.123.1024";
-
+	
 	private final static byte[] VALID_BYTE_ARRAY = new byte[]{0x01, 0x17, 0x7B, (byte)0xEA};
 	private final static int[] VALID_INT_ARRAY = new int[]{1, 23, 123, 234};
 	private final static String VALID_STRING = "1.23.123.234";
-
+	
 	private final static byte[] INCOMPLETE_BYTE_ARRAY = new byte[]{0x00, 0x00, 0x7B, (byte)0xEA};
 	private final static int[] INCOMPLETE_INT_ARRAY = new int[]{123, 234};
-
+	
 	private final static byte[] EXPECTED_BYTE_ARRAY = new byte[]{0x01, 0x17, 0x7B, (byte)0xEA};
 	private final static String EXPECTED_STRING = "1.23.123.234";
-
+	
 	private final static byte[] EXPECTED_INCOMPLETE_BYTE_ARRAY = new byte[]{0x00, 0x00, 0x7B, (byte)0xEA};
 	private final static String EXPECTED_INCOMPLETE_STRING = "0.0.123.234";
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#IP32BitAddress(byte[])},
 	 * {@link com.digi.xbee.api.models.IP32BitAddress#IP32BitAddress(int[])} and
 	 * {@link com.digi.xbee.api.models.IP32BitAddress#IP32BitAddress(String)}.
-	 *
+	 * 
 	 * <p>Verify that IP object cannot be created using invalid parameters.</p>
 	 */
 	@Test
@@ -100,11 +100,11 @@ public class IP32BitAddressTest {
 			assertEquals(e.getClass(), IllegalArgumentException.class);
 		}
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#IP32BitAddress(byte[])}.
-	 *
-	 * <p>Verify that IP Address object can be created using a valid byte
+	 * 
+	 * <p>Verify that IP Address object can be created using a valid byte 
 	 * array and the returned object values are correct.</p>
 	 */
 	@Test
@@ -116,16 +116,16 @@ public class IP32BitAddressTest {
 		} catch (Exception e) {
 			fail("This exception should have not been thrown.");
 		}
-
+		
 		assertArrayEquals(EXPECTED_BYTE_ARRAY, address.getValue());
 		assertEquals(EXPECTED_STRING, address.getValueString());
 		assertEquals(EXPECTED_STRING, address.toString());
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#IP32BitAddress(int[])}.
-	 *
-	 * <p>Verify that IP Address object can be created using a valid int
+	 * 
+	 * <p>Verify that IP Address object can be created using a valid int 
 	 * array and the returned object values are correct.</p>
 	 */
 	@Test
@@ -137,16 +137,16 @@ public class IP32BitAddressTest {
 		} catch (Exception e) {
 			fail("This exception should have not been thrown.");
 		}
-
+		
 		assertArrayEquals(EXPECTED_BYTE_ARRAY, address.getValue());
 		assertEquals(EXPECTED_STRING, address.getValueString());
 		assertEquals(EXPECTED_STRING, address.toString());
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#IP32BitAddress(String)}.
-	 *
-	 * <p>Verify that IP Address object can be created using a valid string
+	 * 
+	 * <p>Verify that IP Address object can be created using a valid string 
 	 * and the returned object values are correct.</p>
 	 */
 	@Test
@@ -158,16 +158,16 @@ public class IP32BitAddressTest {
 		} catch (Exception e) {
 			fail("This exception should have not been thrown.");
 		}
-
+		
 		assertArrayEquals(EXPECTED_BYTE_ARRAY, address.getValue());
 		assertEquals(EXPECTED_STRING, address.getValueString());
 		assertEquals(EXPECTED_STRING, address.toString());
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#IP32BitAddress(byte[])}.
-	 *
-	 * <p>Verify that IP Address object can be created using an incomplete byte
+	 * 
+	 * <p>Verify that IP Address object can be created using an incomplete byte 
 	 * array and the returned object values are correct.</p>
 	 */
 	@Test
@@ -179,16 +179,16 @@ public class IP32BitAddressTest {
 		} catch (Exception e) {
 			fail("This exception should have not been thrown.");
 		}
-
+		
 		assertArrayEquals(EXPECTED_INCOMPLETE_BYTE_ARRAY, address.getValue());
 		assertEquals(EXPECTED_INCOMPLETE_STRING, address.getValueString());
 		assertEquals(EXPECTED_INCOMPLETE_STRING, address.toString());
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#IP32BitAddress(int[])}.
-	 *
-	 * <p>Verify that IP Address object can be created using an incomplete int
+	 * 
+	 * <p>Verify that IP Address object can be created using an incomplete int 
 	 * array and the returned object values are correct.</p>
 	 */
 	@Test
@@ -200,49 +200,49 @@ public class IP32BitAddressTest {
 		} catch (Exception e) {
 			fail("This exception should have not been thrown.");
 		}
-
+		
 		assertArrayEquals(EXPECTED_INCOMPLETE_BYTE_ARRAY, address.getValue());
 		assertEquals(EXPECTED_INCOMPLETE_STRING, address.getValueString());
 		assertEquals(EXPECTED_INCOMPLETE_STRING, address.toString());
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#equals(Object)}.
-	 *
+	 * 
 	 * <p>Test the equals method with a {@code null} value.</p>
 	 */
 	@Test
 	public final void testEqualsWithNull() {
 		// Setup the resources for the test.
 		IP32BitAddress ip = new IP32BitAddress("10.101.2.100");
-
+		
 		// Call the method under test.
 		boolean areEqual = ip.equals(null);
-
+		
 		// Verify the result.
 		assertThat("IP address cannot be equal to null", areEqual, is(equalTo(false)));
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#equals(Object)}.
-	 *
+	 * 
 	 * <p>Test the equals method with a non {@code IP32BitAddress} value.</p>
 	 */
 	@Test
 	public final void testEqualsWithNonIP() {
 		// Setup the resources for the test.
 		IP32BitAddress ip = new IP32BitAddress("10.101.2.100");
-
+		
 		// Call the method under test.
 		boolean areEqual = ip.equals(new Object());
-
+		
 		// Verify the result.
 		assertThat("IP address cannot be equal to an Object", areEqual, is(equalTo(false)));
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress(Object)}.
-	 *
+	 * 
 	 * <p>Test the equals method with different {@code IP32BitAddress}.</p>
 	 */
 	@Test
@@ -250,19 +250,19 @@ public class IP32BitAddressTest {
 		// Setup the resources for the test.
 		IP32BitAddress ip1 = new IP32BitAddress("10.101.2.100");
 		IP32BitAddress ip2 = new IP32BitAddress("192.163.1.100");
-
+		
 		// Call the method under test.
 		boolean areEqual1 = ip1.equals(ip2);
 		boolean areEqual2 = ip2.equals(ip1);
-
+		
 		// Verify the result.
 		assertThat("IP ip1 must be different from IP ip2", areEqual1, is(equalTo(false)));
 		assertThat("IP ip2 must be different from IP ip1", areEqual2, is(equalTo(false)));
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#equals(Object)}.
-	 *
+	 * 
 	 * <p>Test the equals method with equal {@code IP32BitAddress}.</p>
 	 */
 	@Test
@@ -270,16 +270,16 @@ public class IP32BitAddressTest {
 		// Setup the resources for the test.
 		IP32BitAddress ip1 = new IP32BitAddress("10.101.2.100");
 		IP32BitAddress ip2 = new IP32BitAddress("10.101.2.100");
-
+		
 		// Call the method under test.
 		boolean areEqual1 = ip1.equals(ip2);
 		boolean areEqual2 = ip2.equals(ip1);
-
+		
 		// Verify the result.
 		assertThat("IP ip1 must be equal to IP ip2", areEqual1, is(equalTo(true)));
 		assertThat("IP ip2 must be equal to IP ip1", areEqual2, is(equalTo(true)));
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#equals(Object)}.
 	 */
@@ -287,14 +287,14 @@ public class IP32BitAddressTest {
 	public final void testEqualsIsReflexive() {
 		// Setup the resources for the test.
 		IP32BitAddress ip = new IP32BitAddress("10.101.2.100");
-
+		
 		// Call the method under test.
 		boolean areEqual = ip.equals(ip);
-
+		
 		// Verify the result.
 		assertThat("IP ip must be equal to itself", areEqual, is(equalTo(true)));
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#equals(Object)}.
 	 */
@@ -304,18 +304,18 @@ public class IP32BitAddressTest {
 		IP32BitAddress ip1 = new IP32BitAddress("10.101.2.100");
 		IP32BitAddress ip2 = new IP32BitAddress("10.101.2.100");
 		IP32BitAddress ip3 = new IP32BitAddress("10.101.2.100");
-
+		
 		// Call the method under test.
 		boolean areEqual1 = ip1.equals(ip2);
 		boolean areEqual2 = ip2.equals(ip3);
 		boolean areEqual3 = ip1.equals(ip3);
-
+		
 		// Verify the result.
 		assertThat("IP ip1 must be equal to IP ip2", areEqual1, is(equalTo(true)));
 		assertThat("IP ip2 must be equal to IP ip3", areEqual2, is(equalTo(true)));
 		assertThat("IP ip1 must be equal to IP ip3", areEqual3, is(equalTo(true)));
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#equals(Object)}.
 	 */
@@ -325,7 +325,7 @@ public class IP32BitAddressTest {
 		IP32BitAddress ip1 = new IP32BitAddress("10.101.2.100");
 		IP32BitAddress ip2 = new IP32BitAddress("10.101.2.100");
 		IP32BitAddress ip3 = new IP32BitAddress("192.163.1.100");
-
+		
 		// Verify the result.
 		assertThat("Consistent test fail ip1,ip2", ip1.equals(ip2), is(equalTo(true)));
 		assertThat("Consistent test fail ip1,ip2", ip1.equals(ip2), is(equalTo(true)));
@@ -335,7 +335,7 @@ public class IP32BitAddressTest {
 		assertThat("Consistent test fail ip3,ip1", ip3.equals(ip1), is(equalTo(false)));
 
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#hashCode()}.
 	 */
@@ -344,17 +344,17 @@ public class IP32BitAddressTest {
 		// Setup the resources for the test.
 		IP32BitAddress ip1 = new IP32BitAddress("10.101.2.100");
 		IP32BitAddress ip2 = new IP32BitAddress("10.101.2.100");
-
+		
 		// Call the method under test.
 		int hashIP1 = ip1.hashCode();
 		int hashIP2 = ip2.hashCode();
-
+		
 		// Verify the result.
 		assertThat("IP ip1 must be equal to IP ip2", ip1.equals(ip2), is(equalTo(true)));
 		assertThat("IP ip2 must be equal to IP ip1", ip2.equals(ip1), is(equalTo(true)));
 		assertThat("Hash codes must be equal", hashIP1, is(equalTo(hashIP2)));
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#hashCode()}.
 	 */
@@ -363,17 +363,17 @@ public class IP32BitAddressTest {
 		// Setup the resources for the test.
 		IP32BitAddress ip1 = new IP32BitAddress("10.101.2.100");
 		IP32BitAddress ip2 = new IP32BitAddress("192.163.1.100");
-
+		
 		// Call the method under test.
 		int hashIP1 = ip1.hashCode();
 		int hashIP2 = ip2.hashCode();
-
+		
 		// Verify the result.
 		assertThat("IP ip1 must be different from IP ip2", ip1.equals(ip2), is(equalTo(false)));
 		assertThat("IP ip2 must be different from to IP ip1", ip2.equals(ip1), is(equalTo(false)));
 		assertThat("Hash codes must be different", hashIP1, is(not(equalTo(hashIP2))));
 	}
-
+	
 	/**
 	 * Test method for {@link com.digi.xbee.api.models.IP32BitAddress#hashCode()}.
 	 */
@@ -381,9 +381,9 @@ public class IP32BitAddressTest {
 	public final void testHashCodeIsConsistent() {
 		// Setup the resources for the test.
 		IP32BitAddress ip = new IP32BitAddress("10.101.2.100");
-
+		
 		int initialHashCode = ip.hashCode();
-
+		
 		// Verify the result.
 		assertThat("Consistent hashcode test fails", ip.hashCode(), is(equalTo(initialHashCode)));
 		assertThat("Consistent hashcode test fails", ip.hashCode(), is(equalTo(initialHashCode)));

--- a/library/src/test/java/com/digi/xbee/api/models/XBeeIMEIAddressTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/XBeeIMEIAddressTest.java
@@ -1,0 +1,343 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class XBeeIMEIAddressTest {
+	
+	// Constants.
+	private final static byte[] INVALID_BYTE_ARRAY = new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+	private final static String INVALID_STRING = "Hello world";
+	private final static String INVALID_STRING_2 = "0x0123456789ABCDEF0123";
+	
+	private final static byte[] VALID_BYTE_ARRAY = new byte[]{0x01, 0x23, 0x45, 0x67, (byte)0x89, 0x01, 0x23, 0x45};
+	private final static String VALID_STRING = "123456789012345";
+	
+	private final static byte[] INCOMPLETE_BYTE_ARRAY = new byte[]{0x23, 0x45};
+	private final static String INCOMPLETE_STRING = "2345";
+	
+	private final static String EXPECTED_STRING = "123456789012345";
+	private final static String EXPECTED_INCOMPLETE_STRING = "000000000002345";
+	
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#XBeeIMEIAddress(byte[])},
+	 * {@link com.digi.xbee.api.models.XBeeIMEIAddress#XBeeIMEIAddress(int[])} and
+	 * {@link com.digi.xbee.api.models.XBeeIMEIAddress#XBeeIMEIAddress(String)}.
+	 * 
+	 * <p>Verify that IMEI object cannot be created using invalid parameters.</p>
+	 */
+	@Test
+	public void testCreateWithInvalidParameters() {
+		// Test with null byte array.
+		try {
+			new XBeeIMEIAddress((byte[])null);
+			fail("Object should not have been created.");
+		} catch (Exception e) {
+			assertEquals(e.getClass(), NullPointerException.class);
+		}
+		// Test with invalid byte array.
+		try {
+			new XBeeIMEIAddress(INVALID_BYTE_ARRAY);
+			fail("Object should not have been created.");
+		} catch (Exception e) {
+			assertEquals(e.getClass(), IllegalArgumentException.class);
+		}
+		// Test with null string.
+		try {
+			new XBeeIMEIAddress((String)null);
+			fail("Object should not have been created.");
+		} catch (Exception e) {
+			assertEquals(e.getClass(), NullPointerException.class);
+		}
+		// Test with invalid strings.
+		try {
+			new XBeeIMEIAddress(INVALID_STRING);
+			fail("Object should not have been created.");
+		} catch (Exception e) {
+			assertEquals(e.getClass(), IllegalArgumentException.class);
+		}
+		try {
+			new XBeeIMEIAddress(INVALID_STRING_2);
+			fail("Object should not have been created.");
+		} catch (Exception e) {
+			assertEquals(e.getClass(), IllegalArgumentException.class);
+		}
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#XBeeIMEIAddress(byte[])}.
+	 * 
+	 * <p>Verify that IMEI Address object can be created using a valid byte 
+	 * array and the returned object value is correct.</p>
+	 */
+	@Test
+	public void testCreateWithValidByteArray() {
+		// Test with valid byte array.
+		XBeeIMEIAddress imei = null;
+		try {
+			imei = new XBeeIMEIAddress(VALID_BYTE_ARRAY);
+		} catch (Exception e) {
+			fail("This exception should have not been thrown.");
+		}
+		
+		assertEquals(EXPECTED_STRING, imei.getValue());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#XBeeIMEIAddress(String)}.
+	 * 
+	 * <p>Verify that IMEI Address object can be created using a valid string 
+	 * and the returned object value is correct.</p>
+	 */
+	@Test
+	public void testCreateWithValidString() {
+		// Test with valid string.
+		XBeeIMEIAddress imei = null;
+		try {
+			imei = new XBeeIMEIAddress(VALID_STRING);
+		} catch (Exception e) {
+			fail("This exception should have not been thrown.");
+		}
+		
+		assertEquals(EXPECTED_STRING, imei.getValue());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#XBeeIMEIAddress(byte[])}.
+	 * 
+	 * <p>Verify that IMEI Address object can be created using an incomplete byte 
+	 * array and the returned object value is correct.</p>
+	 */
+	@Test
+	public void testCreateWithIncompleteByteArray() {
+		// Test with an incomplete byte array.
+		XBeeIMEIAddress imei = null;
+		try {
+			imei = new XBeeIMEIAddress(INCOMPLETE_BYTE_ARRAY);
+		} catch (Exception e) {
+			fail("This exception should have not been thrown.");
+		}
+		
+		assertEquals(EXPECTED_INCOMPLETE_STRING, imei.getValue());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#XBeeIMEIAddress(String)}.
+	 * 
+	 * <p>Verify that IMEI Address object can be created using an incomplete
+	 * string and the returned object value is correct.</p>
+	 */
+	@Test
+	public void testCreateWithIncompleteString() {
+		// Test with an incomplete string.
+		XBeeIMEIAddress imei = null;
+		try {
+			imei = new XBeeIMEIAddress(INCOMPLETE_STRING);
+		} catch (Exception e) {
+			fail("This exception should have not been thrown.");
+		}
+		
+		assertEquals(EXPECTED_INCOMPLETE_STRING, imei.getValue());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#equals(Object)}.
+	 * 
+	 * <p>Test the equals method with a {@code null} value.</p>
+	 */
+	@Test
+	public final void testEqualsWithNull() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei = new XBeeIMEIAddress("1234");
+		
+		// Call the method under test.
+		boolean areEqual = imei.equals(null);
+		
+		// Verify the result.
+		assertThat("IMEI address cannot be equal to null", areEqual, is(equalTo(false)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#equals(Object)}.
+	 * 
+	 * <p>Test the equals method with a non {@code XBeeIMEIAddress} value.</p>
+	 */
+	@Test
+	public final void testEqualsWithNonIMEI() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei = new XBeeIMEIAddress("1234");
+		
+		// Call the method under test.
+		boolean areEqual = imei.equals(new Object());
+		
+		// Verify the result.
+		assertThat("IMEI address cannot be equal to an Object", areEqual, is(equalTo(false)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress(Object)}.
+	 * 
+	 * <p>Test the equals method with different {@code XBeeIMEIAddress}.</p>
+	 */
+	@Test
+	public final void testEqualsWithDifferentIMEI() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei1 = new XBeeIMEIAddress("1234");
+		XBeeIMEIAddress imei2 = new XBeeIMEIAddress("5678");
+		
+		// Call the method under test.
+		boolean areEqual1 = imei1.equals(imei2);
+		boolean areEqual2 = imei2.equals(imei1);
+		
+		// Verify the result.
+		assertThat("IMEI imei1 must be different from IMEI imei2", areEqual1, is(equalTo(false)));
+		assertThat("IMEI imei2 must be different from IMEI imei1", areEqual2, is(equalTo(false)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#equals(Object)}.
+	 * 
+	 * <p>Test the equals method with equal {@code XBeeIMEIAddress}.</p>
+	 */
+	@Test
+	public final void testEqualsIsSymetric() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei1 = new XBeeIMEIAddress("1234");
+		XBeeIMEIAddress imei2 = new XBeeIMEIAddress("1234");
+		
+		// Call the method under test.
+		boolean areEqual1 = imei1.equals(imei2);
+		boolean areEqual2 = imei2.equals(imei1);
+		
+		// Verify the result.
+		assertThat("IMEI imei1 must be equal to IMEI imei2", areEqual1, is(equalTo(true)));
+		assertThat("IMEI imei2 must be equal to IMEI imei1", areEqual2, is(equalTo(true)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#equals(Object)}.
+	 */
+	@Test
+	public final void testEqualsIsReflexive() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei = new XBeeIMEIAddress("1234");
+		
+		// Call the method under test.
+		boolean areEqual = imei.equals(imei);
+		
+		// Verify the result.
+		assertThat("IMEI imei must be equal to itself", areEqual, is(equalTo(true)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#equals(Object)}.
+	 */
+	@Test
+	public final void testEqualsIsTransitive() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei1 = new XBeeIMEIAddress("1234");
+		XBeeIMEIAddress imei2 = new XBeeIMEIAddress("1234");
+		XBeeIMEIAddress imei3 = new XBeeIMEIAddress("1234");
+		
+		// Call the method under test.
+		boolean areEqual1 = imei1.equals(imei2);
+		boolean areEqual2 = imei2.equals(imei3);
+		boolean areEqual3 = imei1.equals(imei3);
+		
+		// Verify the result.
+		assertThat("IMEI imei1 must be equal to IMEI imei2", areEqual1, is(equalTo(true)));
+		assertThat("IMEI imei2 must be equal to IMEI imei3", areEqual2, is(equalTo(true)));
+		assertThat("IMEI imei1 must be equal to IMEI imei3", areEqual3, is(equalTo(true)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#equals(Object)}.
+	 */
+	@Test
+	public final void testEqualsIsConsistent() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei1 = new XBeeIMEIAddress("1234");
+		XBeeIMEIAddress imei2 = new XBeeIMEIAddress("1234");
+		XBeeIMEIAddress imei3 = new XBeeIMEIAddress("5678");
+		
+		// Verify the result.
+		assertThat("Consistent test fail imei1,imei2", imei1.equals(imei2), is(equalTo(true)));
+		assertThat("Consistent test fail imei1,imei2", imei1.equals(imei2), is(equalTo(true)));
+		assertThat("Consistent test fail imei1,imei2", imei1.equals(imei2), is(equalTo(true)));
+		assertThat("Consistent test fail imei3,imei1", imei3.equals(imei1), is(equalTo(false)));
+		assertThat("Consistent test fail imei3,imei1", imei3.equals(imei1), is(equalTo(false)));
+		assertThat("Consistent test fail imei3,imei1", imei3.equals(imei1), is(equalTo(false)));
+
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#hashCode()}.
+	 */
+	@Test
+	public final void testHashCodeWithEqualPackets() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei1 = new XBeeIMEIAddress("1234");
+		XBeeIMEIAddress imei2 = new XBeeIMEIAddress("1234");
+		
+		// Call the method under test.
+		int hashIMEI1 = imei1.hashCode();
+		int hashIMEI2 = imei2.hashCode();
+		
+		// Verify the result.
+		assertThat("IMEI imei1 must be equal to IMEI imei2", imei1.equals(imei2), is(equalTo(true)));
+		assertThat("IMEI imei2 must be equal to IMEI imei1", imei2.equals(imei1), is(equalTo(true)));
+		assertThat("Hash codes must be equal", hashIMEI1, is(equalTo(hashIMEI2)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#hashCode()}.
+	 */
+	@Test
+	public final void testHashCodeWithDifferentPackets() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei1 = new XBeeIMEIAddress("1234");
+		XBeeIMEIAddress imei2 = new XBeeIMEIAddress("5678");
+		
+		// Call the method under test.
+		int hashIMEI1 = imei1.hashCode();
+		int hashIMEI2 = imei2.hashCode();
+		
+		// Verify the result.
+		assertThat("IMEI imei1 must be different from IMEI imei2", imei1.equals(imei2), is(equalTo(false)));
+		assertThat("IMEI imei2 must be different from to IMEI imei1", imei2.equals(imei1), is(equalTo(false)));
+		assertThat("Hash codes must be different", hashIMEI1, is(not(equalTo(hashIMEI2))));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.XBeeIMEIAddress#hashCode()}.
+	 */
+	@Test
+	public final void testHashCodeIsConsistent() {
+		// Setup the resources for the test.
+		XBeeIMEIAddress imei = new XBeeIMEIAddress("1234");
+		
+		int initialHashCode = imei.hashCode();
+		
+		// Verify the result.
+		assertThat("Consistent hashcode test fails", imei.hashCode(), is(equalTo(initialHashCode)));
+		assertThat("Consistent hashcode test fails", imei.hashCode(), is(equalTo(initialHashCode)));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<slf4j-nop.version>1.7.12</slf4j-nop.version>
 		<junit.version>4.12</junit.version>
 		<mockito.version>1.10.19</mockito.version>
-		<powermock.version>1.6.2</powermock.version>
+		<powermock.version>1.6.6</powermock.version>
 		<cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
 		<asm.plugin.version>5.0.3</asm.plugin.version>
 		<maven.assembly.version>2.5.4</maven.assembly.version>


### PR DESCRIPTION
- Added the CellularDevice class that represents a Cellular radio module.
- Added the intermediate WLANDevice class for Network devices. CellularDevice
  class inherits from it.
- Added new model classes (XBeeIMEIAddress and IP32BitAddress) to represent
  the Cellular module's IMEI address and IP address.
- Added a new enumerator (CellularAssociationIndicationStatus) to list the
  possible association indication status of a Cellular device.
- Added the CELLULAR protocol to the XBeeProtocol enumerator and updated the
  protocol algorithm to determine the Cellular one.
- Written the unit tests for the new code and updated some others.
- Updated the minimum Powermock library to version 1.6.6 to support the new
  test cases.

https://jira.digi.com/browse/XBJAPI-291

Signed-off-by: Diego Escalona <diego.escalona@digi.com>