### PR TITLE
cellular: add WLAN and Cellular communication methods

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
@@ -37,8 +37,10 @@ import com.digi.xbee.api.io.IOValue;
 import com.digi.xbee.api.listeners.IExplicitDataReceiveListener;
 import com.digi.xbee.api.listeners.IIOSampleReceiveListener;
 import com.digi.xbee.api.listeners.IModemStatusReceiveListener;
+import com.digi.xbee.api.listeners.INetworkDataReceiveListener;
 import com.digi.xbee.api.listeners.IPacketReceiveListener;
 import com.digi.xbee.api.listeners.IDataReceiveListener;
+import com.digi.xbee.api.listeners.ISMSReceiveListener;
 import com.digi.xbee.api.models.ATCommand;
 import com.digi.xbee.api.models.ATCommandResponse;
 import com.digi.xbee.api.models.ATCommandStatus;
@@ -797,6 +799,97 @@ public abstract class AbstractXBeeDevice {
 		if (dataReader == null)
 			return;
 		dataReader.removeExplicitDataReceiveListener(listener);
+	}
+	
+	
+	/**
+	 * Adds the provided listener to the list of listeners to be notified
+	 * when new network data is received. 
+	 * 
+	 * <p>If the listener has been already included this method does nothing.
+	 * </p>
+	 * 
+	 * @param listener Listener to be notified when new network data is 
+	 *                 received.
+	 * 
+	 * @throws NullPointerException if {@code listener == null}
+	 * 
+	 * @see #removeNetworkDataListener(INetworkDataReceiveListener)
+	 * @see com.digi.xbee.api.listeners.INetworkDataReceiveListener
+	 */
+	protected void addNetworkDataListener(INetworkDataReceiveListener listener) {
+		if (listener == null)
+			throw new NullPointerException("Listener cannot be null.");
+		
+		if (dataReader == null)
+			return;
+		dataReader.addNetworkDataReceiveListener(listener);
+	}
+	
+	/**
+	 * Removes the provided listener from the list of network data listeners. 
+	 * 
+	 * <p>If the listener was not in the list this method does nothing.</p>
+	 * 
+	 * @param listener Listener to be removed from the list of listeners.
+	 * 
+	 * @throws NullPointerException if {@code listener == null}
+	 * 
+	 * @see #addNetworkDataListener(INetworkDataReceiveListener)
+	 * @see com.digi.xbee.api.listeners.INetworkDataReceiveListener
+	 */
+	protected void removeNetworkDataListener(INetworkDataReceiveListener listener) {
+		if (listener == null)
+			throw new NullPointerException("Listener cannot be null.");
+		
+		if (dataReader == null)
+			return;
+		dataReader.removeNetworkDataReceiveListener(listener);
+	}
+	
+	
+	/**
+	 * Adds the provided listener to the list of listeners to be notified
+	 * when new SMS is received. 
+	 * 
+	 * <p>If the listener has been already included this method does nothing.
+	 * </p>
+	 * 
+	 * @param listener Listener to be notified when new SMS is received.
+	 * 
+	 * @throws NullPointerException if {@code listener == null}
+	 * 
+	 * @see #removeSMSListener(ISMSReceiveListener)
+	 * @see com.digi.xbee.api.listeners.ISMSReceiveListener
+	 */
+	protected void addSMSListener(ISMSReceiveListener listener) {
+		if (listener == null)
+			throw new NullPointerException("Listener cannot be null.");
+		
+		if (dataReader == null)
+			return;
+		dataReader.addSMSReceiveListener(listener);
+	}
+	
+	/**
+	 * Removes the provided listener from the list of SMS listeners. 
+	 * 
+	 * <p>If the listener was not in the list this method does nothing.</p>
+	 * 
+	 * @param listener Listener to be removed from the list of listeners.
+	 * 
+	 * @throws NullPointerException if {@code listener == null}
+	 * 
+	 * @see #addSMSListener(ISMSReceiveListener)
+	 * @see com.digi.xbee.api.listeners.ISMSReceiveListener
+	 */
+	protected void removeSMSListener(ISMSReceiveListener listener) {
+		if (listener == null)
+			throw new NullPointerException("Listener cannot be null.");
+		
+		if (dataReader == null)
+			return;
+		dataReader.removeSMSReceiveListener(listener);
 	}
 	
 	/**

--- a/library/src/main/java/com/digi/xbee/api/WLANDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/WLANDevice.java
@@ -13,14 +13,27 @@ package com.digi.xbee.api;
 
 import com.digi.xbee.api.connection.IConnectionInterface;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.OperationNotSupportedException;
 import com.digi.xbee.api.exceptions.TimeoutException;
 import com.digi.xbee.api.exceptions.XBeeException;
 import com.digi.xbee.api.listeners.IDataReceiveListener;
 import com.digi.xbee.api.listeners.IIOSampleReceiveListener;
+import com.digi.xbee.api.listeners.INetworkDataReceiveListener;
 import com.digi.xbee.api.models.IP32BitAddress;
+import com.digi.xbee.api.models.NetworkMessage;
+import com.digi.xbee.api.models.NetworkProtocol;
 import com.digi.xbee.api.models.XBee16BitAddress;
 import com.digi.xbee.api.models.XBee64BitAddress;
 import com.digi.xbee.api.models.XBeeMessage;
+import com.digi.xbee.api.models.XBeePacketsQueue;
+import com.digi.xbee.api.models.XBeeTransmitOptions;
+import com.digi.xbee.api.packet.XBeeAPIPacket;
+import com.digi.xbee.api.packet.XBeePacket;
+import com.digi.xbee.api.packet.network.RXIPv4Packet;
+import com.digi.xbee.api.packet.network.TXIPv4Packet;
+import com.digi.xbee.api.utils.ByteUtils;
+import com.digi.xbee.api.utils.HexUtils;
 
 /**
  * This class provides common functionality for XBee WLAN devices.
@@ -32,8 +45,16 @@ public class WLANDevice extends XBeeDevice {
 	// Constants
 	private static final String OPERATION_EXCEPTION = "Operation not supported in this module.";
 	
+	protected static final short DEFAULT_SOURCE_PORT = 9750;
+	
+	protected static final NetworkProtocol DEFAULT_PROTOCOL = NetworkProtocol.TCP;
+	
 	// Variables
 	protected IP32BitAddress ipAddress;
+	
+	protected int sourcePort = DEFAULT_SOURCE_PORT;
+	
+	protected NetworkProtocol protocol = DEFAULT_PROTOCOL;
 	
 	/**
 	 * Class constructor. Instantiates a new {@code WLANDevice} object in 
@@ -139,6 +160,17 @@ public class WLANDevice extends XBeeDevice {
 		// Read the module's IP address.
 		byte[] response = getParameter("MY");
 		ipAddress = new IP32BitAddress(response);
+		// Read the source port.
+		try {
+			response = getParameter("C0");
+			sourcePort = ByteUtils.byteArrayToInt(response);
+		} catch (TimeoutException e) {
+			// Do not refresh the source port value if there is an error reading
+			// it from the module.
+		} catch (XBeeException e) {
+			// Do not refresh the source port value if there is an error reading
+			// it from the module.
+		}
 	}
 	
 	/**
@@ -319,5 +351,458 @@ public class WLANDevice extends XBeeDevice {
 			throws XBeeException {
 		// Not supported in WLAN modules.
 		throw new UnsupportedOperationException(OPERATION_EXCEPTION);
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see com.digi.xbee.api.AbstractXBeeDevice#addNetworkDataListener(com.digi.xbee.api.listeners.INetworkDataReceiveListener)
+	 */
+	@Override
+	public void addNetworkDataListener(INetworkDataReceiveListener listener) {
+		super.addNetworkDataListener(listener);
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see com.digi.xbee.api.AbstractXBeeDevice#removeNetworkDataListener(com.digi.xbee.api.listeners.INetworkDataReceiveListener)
+	 */
+	@Override
+	public void removeNetworkDataListener(INetworkDataReceiveListener listener) {
+		super.removeNetworkDataListener(listener);
+	}
+	
+	/**
+	 * Returns the protocol used in network transmissions.
+	 * 
+	 * @return The protocol used in network transmissions.
+	 * 
+	 * @see #setNetworkProtocol(NetworkProtocol)
+	 * @see com.digi.xbee.api.models.NetworkProtocol
+	 */
+	public NetworkProtocol getNetworkProtocol() {
+		return protocol;
+	}
+	
+	/**
+	 * Sets the network protocol used in network transmissions.
+	 * 
+	 * @param protocol The new network protocol to be set for network 
+	 *                 transmissions.
+	 * 
+	 * @see #getNetworkProtocol()
+	 * @see com.digi.xbee.api.models.NetworkProtocol
+	 */
+	public void setNetworkProtocol(NetworkProtocol protocol) {
+		if (protocol == null)
+			throw new NullPointerException("Network protocol cannot be null.");
+		
+		this.protocol = protocol;
+	}
+	
+	/**
+	 * Starts listening for incoming network transmissions in the provided port.
+	 * 
+	 * @param sourcePort Port to listen for incoming transmissions.
+	 * 
+	 * @throws TimeoutException if there is a timeout setting the source port.
+	 * @throws XBeeException if there is any error setting the source port.
+	 * 
+	 * @see #stopListening()
+	 */
+	public void startListening(int sourcePort) throws TimeoutException, XBeeException {
+		if (sourcePort < 0 || sourcePort > 65535)
+			throw new IllegalArgumentException("Source port must be between 0 and 65535.");
+		
+		setParameter("C0", ByteUtils.shortToByteArray((short)sourcePort));
+		this.sourcePort = sourcePort;
+	}
+	
+	/**
+	 * Stops listening for incoming network transmissions.
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 * 
+	 * @see #startListening(short)
+	 */
+	public void stopListening() throws TimeoutException, XBeeException {
+		setParameter("C0", ByteUtils.shortToByteArray((short)0));
+		switch (protocol) {
+		case UDP:
+			setParameter("DE", ByteUtils.shortToByteArray((short)0));
+			break;
+		case TCP:
+		case TCP_SSL:
+		default:
+			break;
+		}
+		sourcePort = 0;
+	}
+	
+	/**
+	 * Sends the provided network data to the given IP address and port.
+	 * 
+	 * <p>This method blocks till a success or error response arrives or the 
+	 * configured receive timeout expires.</p>
+	 * 
+	 * <p>The receive timeout is configured using the {@code setReceiveTimeout}
+	 * method and can be consulted with {@code getReceiveTimeout} method.</p>
+	 * 
+	 * <p>For non-blocking operations use the method 
+	 * {@link #sendNetworkDataAsync(IP32BitAddress, byte[])}.</p>
+	 * 
+	 * @param ipAddress The IP address to send network data to.
+	 * @param destPort The destination port of the transmission.
+	 * @param data Byte array containing the network data to be sent.
+	 * 
+	 * @throws IllegalArgumentException if {@code destPort < 0} or 
+	 *                                  if {@code destPort > 65535}
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws NullPointerException if {@code ipAddress == null} or 
+	 *                              if {@code data == null}.
+	 * @throws TimeoutException if there is a timeout sending the data.
+	 * @throws XBeeException if there is any other XBee related exception.
+	 * 
+	 * @see #getReceiveTimeout()
+	 * @see #setReceiveTimeout(int)
+	 * @see #sendNetworkDataAsync(IP32BitAddress, int, byte[])
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 */
+	public void sendNetworkData(IP32BitAddress ipAddress, int destPort, byte[] data) throws TimeoutException, XBeeException {
+		if (ipAddress == null)
+			throw new NullPointerException("IP address cannot be null");
+		if (data == null)
+			throw new NullPointerException("Data cannot be null");
+		
+		if (destPort < 0 || destPort > 65535)
+			throw new IllegalArgumentException("Destination port must be between 0 and 65535.");
+		
+		// Check if device is remote.
+		if (isRemote())
+			throw new OperationNotSupportedException("Cannot send network data from a remote device.");
+		
+		// The source port value depends on the protocol used in the transmission. For UDP, source port 
+		// value must be the same as 'C0' one. For TCP it must be 0.
+		int sourcePort = this.sourcePort;
+		if (protocol != NetworkProtocol.UDP)
+			sourcePort = 0;
+		
+		logger.debug(toString() + "Sending network data to {}:{} >> {}.", ipAddress, destPort, HexUtils.prettyHexString(data));
+		
+		XBeePacket xbeePacket = new TXIPv4Packet(getNextFrameID(), ipAddress, destPort, sourcePort, protocol, XBeeTransmitOptions.NONE, data);
+		
+		sendAndCheckXBeePacket(xbeePacket, false);
+	}
+	
+	/**
+	 * Sends the provided network data to the to the given IP address and port 
+	 * asynchronously.
+	 * 
+	 * <p>Asynchronous transmissions do not wait for answer from the remote 
+	 * device or for transmit status packet.</p>
+	 * 
+	 * @param ipAddress The IP address to send network data to.
+	 * @param destPort The destination port of the transmission.
+	 * @param data Byte array containing the network data to be sent.
+	 * 
+	 * @throws IllegalArgumentException if {@code destPort < 0} or 
+	 *                                  if {@code destPort > 65535}
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws NullPointerException if {@code ipAddress == null} or 
+	 *                              if {@code data == null}.
+	 * @throws TimeoutException if there is a timeout sending the data.
+	 * @throws XBeeException if there is any other XBee related exception.
+	 * 
+	 * @see #sendNetworkData(IP32BitAddress, int, byte[])
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 */
+	public void sendNetworkDataAsync(IP32BitAddress ipAddress, int destPort, byte[] data) throws XBeeException {
+		if (ipAddress == null)
+			throw new NullPointerException("IP address cannot be null");
+		if (data == null)
+			throw new NullPointerException("Data cannot be null");
+		
+		if (destPort < 0 || destPort > 65535)
+			throw new IllegalArgumentException("Destination port must be between 0 and 65535.");
+		
+		// Check if device is remote.
+		if (isRemote())
+			throw new OperationNotSupportedException("Cannot send network data to a remote device from a remote device.");
+		
+		// The source port value depends on the protocol used in the transmission. For UDP, source port 
+		// value must be the same as 'C0' one. For TCP it must be 0.
+		int sourcePort = this.sourcePort;
+		if (protocol != NetworkProtocol.UDP)
+			sourcePort = 0;
+		
+		logger.debug(toString() + "Sending network data asynchronously to {}:{} >> {}.", ipAddress, destPort, HexUtils.prettyHexString(data));
+		
+		XBeePacket xbeePacket = new TXIPv4Packet(getNextFrameID(), ipAddress, destPort, sourcePort, protocol, XBeeTransmitOptions.NONE, data);
+		
+		sendAndCheckXBeePacket(xbeePacket, true);
+	}
+	
+	/**
+	 * Sends the provided network data to all clients.
+	 * 
+	 * <p>This method blocks till a success or error transmit status arrives or 
+	 * the configured receive timeout expires.</p>
+	 * 
+	 * <p>The receive timeout is configured using the {@code setReceiveTimeout}
+	 * method and can be consulted with {@code getReceiveTimeout} method.</p>
+	 * 
+	 * @param destPort The destination port of the transmission.
+	 * @param data Byte array containing the network data to be sent.
+	 * 
+	 * @throws IllegalArgumentException if {@code destPort < 0} or 
+	 *                                  if {@code destPort > 65535}
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws NullPointerException if {@code data == null}.
+	 * @throws TimeoutException if there is a timeout sending the data.
+	 * @throws XBeeException if there is any other XBee related exception.
+	 * 
+	 * @see #getReceiveTimeout()
+	 * @see #sendNetworkData(IP32BitAddress, int, byte[])
+	 * @see #sendNetworkDataAsync(IP32BitAddress, int, byte[])
+	 * @see #setReceiveTimeout(int)
+	 */
+	public void sendBroadcastNetworkData(int destPort, byte[] data) throws TimeoutException, XBeeException {
+		sendNetworkData(IP32BitAddress.BROADCAST_ADDRESS, destPort, data);
+	}
+	
+	/**
+	 * Reads new network data received by this XBee device during the 
+	 * configured receive timeout.
+	 * 
+	 * <p>This method blocks until new network data is received or the 
+	 * configured receive timeout expires.</p>
+	 * 
+	 * <p>The receive timeout is configured using the {@code setReceiveTimeout}
+	 * method and can be consulted with {@code getReceiveTimeout} method.</p>
+	 * 
+	 * <p>For non-blocking operations, register a {@code INetworkDataReceiveListener} 
+	 * using the method {@link #addNetworkDataListener(INetworkDataReceiveListener)}.</p>
+	 * 
+	 * <p>Before reading network data you need to start listening for incoming 
+	 * network data at a specific port. Use the {@code startListening} method 
+	 * for that purpose. When finished, you can use the {@code stopListening} 
+	 * method to stop listening for incoming network data.</p>
+	 * 
+	 * @return A {@code NetworkMessage} object containing the network data and 
+	 *         the IP address that sent the data. {@code null} if this did not 
+	 *         receive new network data during the configured receive timeout.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * 
+	 * @see #getReceiveTimeout()
+	 * @see #readNetworkData(int)
+	 * @see #readNetworkDataFrom(IP32BitAddress)
+	 * @see #readNetworkDataFrom(IP32BitAddress, int)
+	 * @see #setReceiveTimeout(int)
+	 * @see #startListening(short)
+	 * @see #stopListening()
+	 * @see com.digi.xbee.api.models.NetworkMessage
+	 */
+	public NetworkMessage readNetworkData() {
+		return readNetworkDataPacket(null, TIMEOUT_READ_PACKET);
+	}
+	
+	/**
+	 * Reads new network data received by this XBee device during the provided 
+	 * timeout.
+	 * 
+	 * <p>This method blocks until new network data is received or the provided 
+	 * timeout expires.</p>
+	 * 
+	 * <p>For non-blocking operations, register a {@code INetworkDataReceiveListener} 
+	 * using the method {@link #addNetworkDataListener(INetworkDataReceiveListener)}.</p>
+	 * 
+	 * <p>Before reading network data you need to start listening for incoming 
+	 * network data at a specific port. Use the {@code startListening} method 
+	 * for that purpose. When finished, you can use the {@code stopListening} 
+	 * method to stop listening for incoming network data.</p>
+	 * 
+	 * @param timeout The time to wait for new network data in milliseconds.
+	 * 
+	 * @return A {@code NetworkMessage} object containing the data and the IP 
+	 *         address that sent the data. {@code null} if this device did not 
+	 *         receive new data during {@code timeout} milliseconds.
+	 * 
+	 * @throws IllegalArgumentException if {@code timeout < 0}.
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * 
+	 * @see #readNetworkData()
+	 * @see #readNetworkDataFrom(IP32BitAddress)
+	 * @see #readNetworkDataFrom(IP32BitAddress, int)
+	 * @see #startListening(short)
+	 * @see #stopListening()
+	 * @see com.digi.xbee.api.models.NetworkMessage
+	 */
+	public NetworkMessage readNetworkData(int timeout) {
+		if (timeout < 0)
+			throw new IllegalArgumentException("Read timeout must be 0 or greater.");
+		
+		return readNetworkDataPacket(null, timeout);
+	}
+	
+	/**
+	 * Reads new network data received from the given IP address during the 
+	 * configured receive timeout.
+	 * 
+	 * <p>This method blocks until new data from the provided IP address is 
+	 * received or the configured receive timeout expires.</p>
+	 * 
+	 * <p>The receive timeout is configured using the {@code setReceiveTimeout}
+	 * method and can be consulted with {@code getReceiveTimeout} method.</p>
+	 * 
+	 * <p>For non-blocking operations, register a {@code INetworkDataReceiveListener} 
+	 * using the method {@link #addNetworkDataListener(INetworkDataReceiveListener)}.</p>
+	 * 
+	 * <p>Before reading network data you need to start listening for incoming 
+	 * network data at a specific port. Use the {@code startListening} method 
+	 * for that purpose. When finished, you can use the {@code stopListening} 
+	 * method to stop listening for incoming network data.</p>
+	 * 
+	 * @param ipAddress The IP address to read data from.
+	 * 
+	 * @return A {@code NetworkMessage} object containing the network data and 
+	 *         the IP address of the remote node that sent the data. 
+	 *         {@code null} if this device did not receive new network data 
+	 *         from the provided IP address during the configured receive 
+	 *         timeout.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws NullPointerException if {@code ipAddress == null}.
+	 * 
+	 * @see #getReceiveTimeout()
+	 * @see #readNetworkData()
+	 * @see #readNetworkData(int)
+	 * @see #readNetworkDataFrom(IP32BitAddress, int)
+	 * @see #setReceiveTimeout(int)
+	 * @see #startListening(short)
+	 * @see #stopListening()
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 * @see com.digi.xbee.api.models.NetworkMessage
+	 */
+	public NetworkMessage readNetworkDataFrom(IP32BitAddress ipAddress) {
+		if (ipAddress == null)
+			throw new NullPointerException("IP address cannot be null.");
+		
+		return readNetworkDataPacket(ipAddress, TIMEOUT_READ_PACKET);
+	}
+	
+	/**
+	 * Reads new network data received from the given IP address during the 
+	 * provided timeout.
+	 * 
+	 * <p>This method blocks until new network data from the provided IP 
+	 * address is received or the given timeout expires.</p>
+	 * 
+	 * <p>For non-blocking operations, register a {@code INetworkDataReceiveListener} 
+	 * using the method {@link #addNetworkDataListener(INetworkDataReceiveListener)}.</p>
+	 * 
+	 * <p>Before reading network data you need to start listening for incoming 
+	 * network data at a specific port. Use the {@code startListening} method 
+	 * for that purpose. When finished, you can use the {@code stopListening} 
+	 * method to stop listening for incoming network data.</p>
+	 * 
+	 * @param ipAddress The IP address to read data from.
+	 * @param timeout The time to wait for new network data in milliseconds.
+	 * 
+	 * @return A {@code NetworkMessage} object containing the network data and 
+	 *         the IP address that sent the data. {@code null} if this device 
+	 *         did not receive new network data from the provided IP address 
+	 *         during {@code timeout} milliseconds.
+	 * 
+	 * @throws IllegalArgumentException if {@code timeout < 0}.
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws NullPointerException if {@code ipAddress == null}.
+	 * 
+	 * @see #readNetworkDataFrom(IP32BitAddress)
+	 * @see #readNetworkData()
+	 * @see #readNetworkData(int)
+	 * @see #startListening(short)
+	 * @see #stopListening()
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 * @see com.digi.xbee.api.models.NetworkMessage
+	 */
+	public NetworkMessage readNetworkDataFrom(IP32BitAddress ipAddress, int timeout) {
+		if (ipAddress == null)
+			throw new NullPointerException("IP address cannot be null.");
+		if (timeout < 0)
+			throw new IllegalArgumentException("Read timeout must be 0 or greater.");
+		
+		return readNetworkDataPacket(ipAddress, timeout);
+	}
+	
+	/**
+	 * Reads a new network data packet received by this WLAN XBee device during 
+	 * the provided timeout.
+	 * 
+	 * <p>This method blocks until new network data is received or the given 
+	 * timeout expires.</p>
+	 * 
+	 * <p>If the provided IP address is {@code null} the method returns 
+	 * the first network data packet read from any IP address.
+	 * <br>
+	 * If the IP address is not {@code null} the method returns the first 
+	 * data package read from the provided IP address.
+	 * </p>
+	 * 
+	 * @param remoteIPAddress The IP address to get a network data packet from. 
+	 *                        {@code null} to read a network data packet from 
+	 *                        any IP address.
+	 * @param timeout The time to wait for a network data packet in milliseconds.
+	 * 
+	 * @return A {@code NetworkMessage} received by this device, containing the 
+	 *         data and the source IP address that sent the network data. 
+	 *         {@code null} if this device did not receive new network data 
+	 *         during {@code timeout} milliseconds, or if any error occurs while
+	 *         trying to get the source of the message.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * 
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 * @see com.digi.xbee.api.models.XBeeMessage
+	 */
+	private NetworkMessage readNetworkDataPacket(IP32BitAddress remoteIPAddress, int timeout) {
+		// Check connection.
+		if (!connectionInterface.isOpen())
+			throw new InterfaceNotOpenException();
+		
+		XBeePacketsQueue xbeePacketsQueue = dataReader.getXBeePacketsQueue();
+		XBeePacket xbeePacket = null;
+		
+		if (remoteIPAddress != null)
+			xbeePacket = xbeePacketsQueue.getFirstNetworkDataPacketFrom(remoteIPAddress, timeout);
+		else
+			xbeePacket = xbeePacketsQueue.getFirstNetworkDataPacket(timeout);
+		
+		if (xbeePacket == null)
+			return null;
+		
+		// Obtain the data and IP address from the packet.
+		byte[] data = null;
+		IP32BitAddress ipAddress = null;
+		int sourcePort;
+		int destPort;
+		NetworkProtocol protocol = NetworkProtocol.TCP;
+		boolean isBroadcast = false;
+		
+		switch (((XBeeAPIPacket)xbeePacket).getFrameType()) {
+		case RX_IPV4:
+			RXIPv4Packet receivePacket = (RXIPv4Packet)xbeePacket;
+			data = receivePacket.getData();
+			ipAddress = receivePacket.getDestAddress();
+			sourcePort = receivePacket.getSourcePort();
+			destPort = receivePacket.getDestPort();
+			isBroadcast = receivePacket.isBroadcast();
+			break;
+		default:
+			return null;
+		}
+		
+		// Create and return the XBee message.
+		return new NetworkMessage(ipAddress, sourcePort, destPort, protocol, data, isBroadcast);
 	}
 }

--- a/library/src/main/java/com/digi/xbee/api/XBeeDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/XBeeDevice.java
@@ -63,7 +63,7 @@ public class XBeeDevice extends AbstractXBeeDevice {
 
 	// Constants.
 	private static int TIMEOUT_RESET = 5000;
-	private static int TIMEOUT_READ_PACKET = 3000;
+	protected static int TIMEOUT_READ_PACKET = 3000;
 	
 	private static String COMMAND_MODE_CHAR = "+";
 	private static String COMMAND_MODE_OK = "OK\r";

--- a/library/src/main/java/com/digi/xbee/api/listeners/INetworkDataReceiveListener.java
+++ b/library/src/main/java/com/digi/xbee/api/listeners/INetworkDataReceiveListener.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.listeners;
+
+import com.digi.xbee.api.models.NetworkMessage;
+
+/**
+ * This interface defines the required methods that should be implemented to 
+ * behave as a network data listener and be notified when new network data is 
+ * received from a remote XBee device of the network.
+ */
+public interface INetworkDataReceiveListener {
+
+	/**
+	 * Called when network data is received.
+	 * 
+	 * @param networkMessage An {@code NetworkMessage} object containing the 
+	 *                       data, the {@code IP32BitAddress} that sent the 
+	 *                       data and a flag indicating whether the data was 
+	 *                       sent via broadcast or not.
+	 * 
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 * @see com.digi.xbee.api.models.NetworkMessage
+	 */
+	public void networkDataReceived(NetworkMessage networkMessage);
+}

--- a/library/src/main/java/com/digi/xbee/api/listeners/ISMSReceiveListener.java
+++ b/library/src/main/java/com/digi/xbee/api/listeners/ISMSReceiveListener.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.listeners;
+
+import com.digi.xbee.api.models.SMSMessage;
+
+/**
+ * This interface defines the required methods that should be implemented to 
+ * behave as an SMS listener and be notified when new SMS is received.
+ */
+public interface ISMSReceiveListener {
+
+	/**
+	 * Called when SMS is received.
+	 * 
+	 * @param smsMessage An {@code SMSMessage} object containing the SMS text 
+	 *                   and the phone number that sent the message.
+	 * 
+	 * @see com.digi.xbee.api.models.SMSMessage
+	 */
+	public void smsReceived(SMSMessage smsMessage);
+}

--- a/library/src/main/java/com/digi/xbee/api/models/NetworkMessage.java
+++ b/library/src/main/java/com/digi/xbee/api/models/NetworkMessage.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+/**
+ * This class represents a network message containing the IP address the 
+ * message belongs to, the source and destination ports, the network protocol,
+ * the content (data) of the message and a flag indicating if the message is 
+ * a broadcast message (was received or is being sent via broadcast). 
+ * 
+ * <p>This class is used within the XBee Java Library to read data sent to WLAN 
+ * devices.</p>
+ */
+public class NetworkMessage {
+
+	// Variables.
+	private final IP32BitAddress ipAddress;
+	
+	private final byte[] data;
+	
+	private final int sourcePort;
+	private final int destPort;
+	
+	private final NetworkProtocol protocol;
+	
+	private boolean isBroadcast;
+	
+	/**
+	 * Class constructor. Instantiates a new object of type 
+	 * {@code NetworkMessage} with the given parameters.
+	 * 
+	 * @param ipAddress The IP address the message comes from.
+	 * @param sourcePort TCP or UDP source port of the transmission.
+	 * @param destPort TCP or UDP destination port of the transmission.
+	 * @param protocol Network protocol used in the transmission. 
+	 * @param data Byte array containing the data of the message.
+	 * 
+	 * @throws IllegalArgumentException if {@code sourcePort < 0} or
+	 *                                  if {@code sourcePort > 65535} or
+	 *                                  if {@code destPort < 0} or
+	 *                                  if {@code destPort > 65535}.
+	 * @throws NullPointerException if {@code ipAddress == null} or
+	 *                              if {@code data == null} or
+	 *                              if {@code protocol ==  null}.
+	 * 
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 * @see com.digi.xbee.api.models.NetworkProtocol
+	 */
+	public NetworkMessage(IP32BitAddress ipAddress, int sourcePort, int destPort, 
+			NetworkProtocol protocol, byte[] data) {
+		this(ipAddress, sourcePort, destPort, protocol, data, false);
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new object of type 
+	 * {@code XBeeMessage} with the given parameters.
+	 * 
+	 * @param ipAddress The IP address the message comes from.
+	 * @param data Byte array containing the data of the message.
+	 * @param isBroadcast Indicates if the message was received via broadcast.
+	 * 
+	 * @throws IllegalArgumentException if {@code sourcePort < 0} or
+	 *                                  if {@code sourcePort > 65535} or
+	 *                                  if {@code destPort < 0} or
+	 *                                  if {@code destPort > 65535}.
+	 * @throws NullPointerException if {@code ipAddress == null} or
+	 *                              if {@code data == null} or
+	 *                              if {@code protocol ==  null}.
+	 * 
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 * @see com.digi.xbee.api.models.NetworkProtocol
+	 */
+	public NetworkMessage(IP32BitAddress ipAddress, int sourcePort, int destPort, 
+			NetworkProtocol protocol, byte[] data, boolean isBroadcast) {
+		if (ipAddress == null)
+			throw new NullPointerException("IP address cannot be null.");
+		if (protocol == null)
+			throw new NullPointerException("Protocol cannot be null.");
+		if (data == null)
+			throw new NullPointerException("Data cannot be null.");
+		
+		if (sourcePort < 0 || sourcePort > 65535)
+			throw new IllegalArgumentException("Source port must be between 0 and 65535.");
+		if (destPort < 0 || destPort > 65535)
+			throw new IllegalArgumentException("Destination port must be between 0 and 65535.");
+		
+		this.ipAddress = ipAddress;
+		this.sourcePort = sourcePort;
+		this.destPort = destPort;
+		this.protocol = protocol;
+		this.data = data;
+		this.isBroadcast = isBroadcast;
+	}
+	
+	/**
+	 * Returns the IP address this message is associated to.
+	 * 
+	 * @return The IP address this message is associated to.
+	 * 
+	 * @see com.digi.xbee.api.models.IP32BitAddress
+	 */
+	public IP32BitAddress getIPAddress() {
+		return ipAddress;
+	}
+	
+	/**
+	 * Returns the source port of the transmission.
+	 * 
+	 * @return The source port of the transmission.
+	 */
+	public int getSourcePort() {
+		return sourcePort;
+	}
+	
+	/**
+	 * returns the destination port of the transmission.
+	 * 
+	 * @return The destination port of the transmission.
+	 */
+	public int getDestPort() {
+		return destPort;
+	}
+	
+	/**
+	 * Returns the protocol used in the transmission.
+	 * 
+	 * @return The protocol used in the transmission
+	 * 
+	 * @see NetworkProtocol
+	 */
+	public NetworkProtocol getProtocol() {
+		return protocol;
+	}
+	
+	/**
+	 * Returns the byte array containing the data of the message.
+	 * 
+	 * @return A byte array containing the data of the message.
+	 */
+	public byte[] getData() {
+		return data;
+	}
+	
+	/**
+	 * Returns the data of the message in string format.
+	 * 
+	 * @return The data of the message in string format.
+	 */
+	public String getDataString() {
+		return new String(data);
+	}
+	
+	/**
+	 * Returns whether or not the message was received via broadcast.
+	 * 
+	 * @return {@code true} if the message was received via broadcast, 
+	 *         {@code false} otherwise.
+	 */
+	public boolean isBroadcast() {
+		return isBroadcast;
+	}
+}

--- a/library/src/main/java/com/digi/xbee/api/models/SMSMessage.java
+++ b/library/src/main/java/com/digi/xbee/api/models/SMSMessage.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+/**
+ * This class represents an SMS message containing the phone number that sent  
+ * the message and the content (data) of the message. 
+ * 
+ * <p>This class is used within the XBee Java Library to read SMS sent to 
+ * Cellular devices.</p>
+ */
+public class SMSMessage {
+
+	// Variables.
+	private final String phoneNumber;
+	private final String data;
+	
+	/**
+	 * Class constructor. Instantiates a new object of type 
+	 * {@code SMSMessage} with the given parameters.
+	 * 
+	 * @param phoneNumber The phone number that sent the message.
+	 * @param data String containing the message text.
+	 * 
+	 * @throws NullPointerException if {@code phoneNumber == null} or
+	 *                              if {@code data == null}.
+	 */
+	public SMSMessage(String phoneNumber, String data) {
+		if (phoneNumber == null)
+			throw new NullPointerException("Phone number cannot be null.");
+		if (data == null)
+			throw new NullPointerException("Data cannot be null.");
+		
+		this.phoneNumber = phoneNumber;
+		this.data = data;
+	}
+	
+	/**
+	 * Returns the phone number that sent the message.
+	 * 
+	 * @return The phone number that sent the message.
+	 */
+	public String getPhoneNumber() {
+		return phoneNumber;
+	}
+	
+	/**
+	 * Returns a string containing the data of the message.
+	 * 
+	 * @return A string containing the data of the message.
+	 */
+	public String getData() {
+		return data;
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/SendBroadcastNetworkDataTest.java
+++ b/library/src/test/java/com/digi/xbee/api/SendBroadcastNetworkDataTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.models.IP32BitAddress;
+
+public class SendBroadcastNetworkDataTest {
+	
+	// Constants.
+	private static final String DATA = "data";
+	
+	private static final int PORT = 123456;
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendBroadcastNetworkData(int, byte[])}.
+	 * 
+	 * <p>Verify that broadcast network data can be sent successfully.</p>
+	 */
+	@Test
+	public void testSendBroadcastNetworkDataSuccess() throws Exception {
+		// Instantiate an WLANDevice object with a mocked interface.
+		WLANDevice wlanDevice = PowerMockito.spy(new WLANDevice(Mockito.mock(SerialPortRxTx.class)));
+		
+		// Do nothing when the sendNetowrkData(IP32BitAddress, int, byte[]) method is called.
+		Mockito.doNothing().when(wlanDevice).sendNetworkData(Mockito.any(IP32BitAddress.class), Mockito.any(int.class), Mockito.any(byte[].class));
+				
+		wlanDevice.sendBroadcastNetworkData(PORT, DATA.getBytes());
+		
+		// Verify that the method sendData(XBee64BitAddress, byte[]) was called with a BROADCAST_ADDRESS.
+		Mockito.verify(wlanDevice, Mockito.times(1)).sendNetworkData(Mockito.eq(IP32BitAddress.BROADCAST_ADDRESS), Mockito.eq(PORT), Mockito.eq(DATA.getBytes()));
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/SendNetworkDataAsyncTest.java
+++ b/library/src/test/java/com/digi/xbee/api/SendNetworkDataAsyncTest.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
+import com.digi.xbee.api.exceptions.OperationNotSupportedException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.TransmitException;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.models.IP32BitAddress;
+import com.digi.xbee.api.packet.network.TXIPv4Packet;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({WLANDevice.class})
+public class SendNetworkDataAsyncTest {
+	
+	// Constants.
+	private static final IP32BitAddress IP_ADDRESS = new IP32BitAddress("10.101.2.123");
+	
+	private static final int PORT = 12345;
+	
+	private static final String DATA = "data";
+	
+	// Variables.
+	private WLANDevice wlanDevice;
+	
+	private TXIPv4Packet txIPv4Packet;
+	
+	@Before
+	public void setup() throws Exception {
+		// Instantiate a WLANDevice object with a mocked interface.
+		wlanDevice = PowerMockito.spy(new WLANDevice(Mockito.mock(SerialPortRxTx.class)));
+		
+		// Mock TX IPv4 packet.
+		txIPv4Packet = Mockito.mock(TXIPv4Packet.class);
+		
+		// Whenever a TXIPv4Packet class is instantiated, the mocked txIPv4Packet packet should be returned.
+		PowerMockito.whenNew(TXIPv4Packet.class).withAnyArguments().thenReturn(txIPv4Packet);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if the IP address is {@code null}.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSendNetworkDataAsyncIPNull() throws TimeoutException, XBeeException {
+		wlanDevice.sendNetworkDataAsync(null, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if the destination port is bigger than 65535.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testSendNetworkDataAsyncIllegalPortBig() throws TimeoutException, XBeeException {
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, 100000, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if the destination port is negative.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testSendNetworkDataAsyncIllegalPortNegative() throws TimeoutException, XBeeException {
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, -10, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if the network data is {@code null}.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSendNetworkDataAsyncDataNull() throws TimeoutException, XBeeException {
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, PORT, null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if the sender is a remote XBee device.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=OperationNotSupportedException.class)
+	public void testSendNetworkDataAsyncFromRemoteDevices() throws TimeoutException, XBeeException {
+		// Return that the WLAN device is remote when asked.
+		Mockito.when(wlanDevice.isRemote()).thenReturn(true);
+		
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if the device is not open.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public void testSendNetworkDataAsyncConnectionClosed() throws TimeoutException, XBeeException {
+		// Throw an Interface not open exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new InterfaceNotOpenException()).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(true));
+		
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if the device has an invalid operating mode.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public void testSendNetworkDataAsyncInvalidOperatingMode() throws TimeoutException, XBeeException {
+		// Throw an invalid operating mode exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new InvalidOperatingModeException()).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(true));
+		
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if there is a timeout sending and checking the Tx IPv4 packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public void testSendNetworkDataAsyncTimeout() throws TimeoutException, XBeeException {
+		// Throw a timeout exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new TimeoutException()).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(true));
+		
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if there is a transmit exception when sending and checking the Tx IPv4 packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TransmitException.class)
+	public void testSendNetworkDataAsyncTransmitException() throws TimeoutException, XBeeException {
+		// Throw a transmit exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new TransmitException(null)).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(true));
+		
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data cannot be sent if there is an IO error when sending and checking the Tx IPv4 packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=XBeeException.class)
+	public void testSendNetworkDataAsyncIOException() throws TimeoutException, XBeeException {
+		// Throw an XBee exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new XBeeException()).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(true));
+		
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that async. network data is sent successfully if there is not any error when sending and checking the Tx IPv4 packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test
+	public void testSendNetworkDataAsyncSuccess() throws TimeoutException, XBeeException {
+		// Do nothing when sending and checking any Tx IPv4 packet.
+		Mockito.doNothing().when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(true));
+		
+		wlanDevice.sendNetworkDataAsync(IP_ADDRESS, PORT, DATA.getBytes());
+		
+		// Verify the sendAndCheckXBeePacket(XBeePacket, boolean) method was called.
+		Mockito.verify(wlanDevice, Mockito.times(1)).sendAndCheckXBeePacket(Mockito.eq(txIPv4Packet), Mockito.eq(true));
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/SendNetworkDataTest.java
+++ b/library/src/test/java/com/digi/xbee/api/SendNetworkDataTest.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
+import com.digi.xbee.api.exceptions.OperationNotSupportedException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.TransmitException;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.models.IP32BitAddress;
+import com.digi.xbee.api.packet.network.TXIPv4Packet;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({WLANDevice.class})
+public class SendNetworkDataTest {
+	
+	// Constants.
+	private static final IP32BitAddress IP_ADDRESS = new IP32BitAddress("10.101.2.123");
+	
+	private static final int PORT = 12345;
+	
+	private static final String DATA = "data";
+	
+	// Variables.
+	private WLANDevice wlanDevice;
+	
+	private TXIPv4Packet txIPv4Packet;
+	
+	@Before
+	public void setup() throws Exception {
+		// Instantiate a WLANDevice object with a mocked interface.
+		wlanDevice = PowerMockito.spy(new WLANDevice(Mockito.mock(SerialPortRxTx.class)));
+		
+		// Mock TX IPv4 packet.
+		txIPv4Packet = Mockito.mock(TXIPv4Packet.class);
+		
+		// Whenever a TXIPv4Packet class is instantiated, the mocked txIPv4Packet packet should be returned.
+		PowerMockito.whenNew(TXIPv4Packet.class).withAnyArguments().thenReturn(txIPv4Packet);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if the IP address is {@code null}.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSendNetworkDataIPNull() throws TimeoutException, XBeeException {
+		wlanDevice.sendNetworkData(null, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if the destination port is bigger than 65535.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testSendNetworkDataIllegalPortBig() throws TimeoutException, XBeeException {
+		wlanDevice.sendNetworkData(IP_ADDRESS, 100000, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if the destination port is negative.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testSendNetworkDataIllegalPortNegative() throws TimeoutException, XBeeException {
+		wlanDevice.sendNetworkData(IP_ADDRESS, -10, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if the network data is {@code null}.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSendNetworkDataDataNull() throws TimeoutException, XBeeException {
+		wlanDevice.sendNetworkData(IP_ADDRESS, PORT, null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if the sender is a remote XBee device.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=OperationNotSupportedException.class)
+	public void testSendNetworkDataFromRemoteDevices() throws TimeoutException, XBeeException {
+		// Return that the WLAN device is remote when asked.
+		Mockito.when(wlanDevice.isRemote()).thenReturn(true);
+		
+		wlanDevice.sendNetworkData(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if the device is not open.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public void testSendNetworkDataConnectionClosed() throws TimeoutException, XBeeException {
+		// Throw an Interface not open exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new InterfaceNotOpenException()).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(false));
+		
+		wlanDevice.sendNetworkData(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if the device has an invalid operating mode.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public void testSendNetworkDataInvalidOperatingMode() throws TimeoutException, XBeeException {
+		// Throw an invalid operating mode exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new InvalidOperatingModeException()).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(false));
+		
+		wlanDevice.sendNetworkData(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if there is a timeout sending and checking the Tx IPv4 packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public void testSendNetworkDataTimeout() throws TimeoutException, XBeeException {
+		// Throw a timeout exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new TimeoutException()).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(false));
+		
+		wlanDevice.sendNetworkData(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if there is a transmit exception when sending and checking the Tx IPv4 packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TransmitException.class)
+	public void testSendNetworkDataTransmitException() throws TimeoutException, XBeeException {
+		// Throw a transmit exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new TransmitException(null)).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(false));
+		
+		wlanDevice.sendNetworkData(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data cannot be sent if there is an IO error when sending and checking the Tx IPv4 packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=XBeeException.class)
+	public void testSendNetworkDataIOException() throws TimeoutException, XBeeException {
+		// Throw an XBee exception when sending and checking any Tx IPv4 packet.
+		Mockito.doThrow(new XBeeException()).when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(false));
+		
+		wlanDevice.sendNetworkData(IP_ADDRESS, PORT, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#sendNetworkData(IP32BitAddress, int, byte[])}.
+	 * 
+	 * <p>Verify that network data is sent successfully if there is not any error when sending and checking the Tx IPv4 packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test
+	public void testSendNetworkDataSuccess() throws TimeoutException, XBeeException {
+		// Do nothing when sending and checking any Tx IPv4 packet.
+		Mockito.doNothing().when(wlanDevice).sendAndCheckXBeePacket(Mockito.any(TXIPv4Packet.class), Mockito.eq(false));
+		
+		wlanDevice.sendNetworkData(IP_ADDRESS, PORT, DATA.getBytes());
+		
+		// Verify the sendAndCheckXBeePacket(XBeePacket, boolean) method was called.
+		Mockito.verify(wlanDevice, Mockito.times(1)).sendAndCheckXBeePacket(Mockito.eq(txIPv4Packet), Mockito.eq(false));
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/SendSMSAsyncTest.java
+++ b/library/src/test/java/com/digi/xbee/api/SendSMSAsyncTest.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
+import com.digi.xbee.api.exceptions.OperationNotSupportedException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.TransmitException;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.packet.cellular.TXSMSPacket;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CellularDevice.class})
+public class SendSMSAsyncTest {
+	
+	// Constants.
+	private static final String PHONE = "+155512345678";
+	private static final String DATA = "This is the text";
+	
+	// Variables.
+	private CellularDevice cellularDevice;
+	
+	private TXSMSPacket smsPacket;
+	
+	@Before
+	public void setup() throws Exception {
+		// Instantiate an CellularDevice object with a mocked interface.
+		cellularDevice = PowerMockito.spy(new CellularDevice(Mockito.mock(SerialPortRxTx.class)));
+		
+		// Mock SMS packet.
+		smsPacket = Mockito.mock(TXSMSPacket.class);
+		
+		// Whenever a TXSMSPacket class is instantiated, the mocked smsPacket packet should be returned.
+		PowerMockito.whenNew(TXSMSPacket.class).withAnyArguments().thenReturn(smsPacket);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS cannot be sent if the phone number is {@code null}.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSendSMSAsync64BitAddrNull() throws TimeoutException, XBeeException {
+		cellularDevice.sendSMSAsync(null, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS cannot be sent if the data is {@code null}.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSendSMSAsyncDataNull() throws TimeoutException, XBeeException {
+		cellularDevice.sendSMSAsync(PHONE, null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS cannot be sent if the sender is a remote XBee device.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=OperationNotSupportedException.class)
+	public void testSendSMSAsyncFromRemoteDevices() throws TimeoutException, XBeeException {
+		// Return that the XBee device is remote when asked.
+		Mockito.when(cellularDevice.isRemote()).thenReturn(true);
+		
+		cellularDevice.sendSMSAsync(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS cannot be sent if the device is not open.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public void testSendSMSAsyncConnectionClosed() throws TimeoutException, XBeeException {
+		// Throw an Interface not open exception when sending and checking any SMS packet.
+		Mockito.doThrow(new InterfaceNotOpenException()).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(true));
+		
+		cellularDevice.sendSMSAsync(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS cannot be sent if the device has an invalid operating mode.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public void testSendSMSAsyncInvalidOperatingMode() throws TimeoutException, XBeeException {
+		// Throw an invalid operating mode exception when sending and checking any SMS packet.
+		Mockito.doThrow(new InvalidOperatingModeException()).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(true));
+		
+		cellularDevice.sendSMSAsync(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS cannot be sent if there is a timeout sending and checking the SMS packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public void testSendSMSAsyncTimeout() throws TimeoutException, XBeeException {
+		// Throw a timeout exception when sending and checking any SMS packet.
+		Mockito.doThrow(new TimeoutException()).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(true));
+		
+		cellularDevice.sendSMSAsync(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS cannot be sent if there is a transmit exception when sending and checking the SMS packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TransmitException.class)
+	public void testSendSMSAsyncTransmitException() throws TimeoutException, XBeeException {
+		// Throw a transmit exception when sending and checking any SMS packet.
+		Mockito.doThrow(new TransmitException(null)).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(true));
+		
+		cellularDevice.sendSMSAsync(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS cannot be sent if there is an IO error when sending and checking the SMS packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=XBeeException.class)
+	public void testSendSMSAsyncIOException() throws TimeoutException, XBeeException {
+		// Throw an XBee exception when sending and checking any SMS packet.
+		Mockito.doThrow(new XBeeException()).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(true));
+		
+		cellularDevice.sendSMSAsync(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMSAsync(String, String)}.
+	 * 
+	 * <p>Verify that async. SMS is sent successfully if there is not any error when sending and checking the SMS packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test
+	public void testSendSMSAsyncSuccess() throws TimeoutException, XBeeException {
+		// Do nothing when sending and checking any SMS packet.
+		Mockito.doNothing().when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(true));
+		
+		cellularDevice.sendSMSAsync(PHONE, DATA);
+		
+		// Verify the sendAndCheckXBeePacket(XBeePacket, boolean) method was called.
+		Mockito.verify(cellularDevice, Mockito.times(1)).sendAndCheckXBeePacket(Mockito.eq(smsPacket), Mockito.eq(true));
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/SendSMSTest.java
+++ b/library/src/test/java/com/digi/xbee/api/SendSMSTest.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
+import com.digi.xbee.api.exceptions.OperationNotSupportedException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.TransmitException;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.packet.cellular.TXSMSPacket;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CellularDevice.class})
+public class SendSMSTest {
+	
+	// Constants.
+	private static final String PHONE = "+155512345678";
+	private static final String DATA = "This is the text";
+	
+	// Variables.
+	private CellularDevice cellularDevice;
+	
+	private TXSMSPacket smsPacket;
+	
+	@Before
+	public void setup() throws Exception {
+		// Instantiate a CellularDevice object with a mocked interface.
+		cellularDevice = PowerMockito.spy(new CellularDevice(Mockito.mock(SerialPortRxTx.class)));
+		
+		// Mock Transmit Request packet.
+		smsPacket = Mockito.mock(TXSMSPacket.class);
+		
+		// Whenever a TXSMSPacket class is instantiated, the mocked smsPacket packet should be returned.
+		PowerMockito.whenNew(TXSMSPacket.class).withAnyArguments().thenReturn(smsPacket);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS cannot be sent if the phone number is {@code null}.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSendSMSPhoneNull() throws TimeoutException, XBeeException {
+		cellularDevice.sendSMS(null, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS cannot be sent if the data is {@code null}.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSendSMSDataNull() throws TimeoutException, XBeeException {
+		cellularDevice.sendSMS(PHONE, null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS cannot be sent if the sender is a remote XBee device.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=OperationNotSupportedException.class)
+	public void testSendSMSFromRemoteDevices() throws TimeoutException, XBeeException {
+		// Return that the XBee device is remote when asked.
+		Mockito.when(cellularDevice.isRemote()).thenReturn(true);
+		
+		cellularDevice.sendSMS(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS cannot be sent if the device is not open.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public void testSendSMSConnectionClosed() throws TimeoutException, XBeeException {
+		// Throw an Interface not open exception when sending and checking any SMS packet.
+		Mockito.doThrow(new InterfaceNotOpenException()).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(false));
+		
+		cellularDevice.sendSMS(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS cannot be sent if the device has an invalid operating mode.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public void testSendSMSInvalidOperatingMode() throws TimeoutException, XBeeException {
+		// Throw an invalid operating mode exception when sending and checking any SMS packet.
+		Mockito.doThrow(new InvalidOperatingModeException()).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(false));
+		
+		cellularDevice.sendSMS(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS cannot be sent if there is a timeout sending and checking the SMS packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public void testSendSMSTimeout() throws TimeoutException, XBeeException {
+		// Throw a timeout exception when sending and checking any SMS packet.
+		Mockito.doThrow(new TimeoutException()).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(false));
+		
+		cellularDevice.sendSMS(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS cannot be sent if there is a transmit exception when sending and checking the SMS packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TransmitException.class)
+	public void testSendSMSTransmitException() throws TimeoutException, XBeeException {
+		// Throw a transmit exception when sending and checking any SMS packet.
+		Mockito.doThrow(new TransmitException(null)).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(false));
+		
+		cellularDevice.sendSMS(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS cannot be sent if there is an IO error when sending and checking the SMS packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=XBeeException.class)
+	public void testSendSMSIOException() throws TimeoutException, XBeeException {
+		// Throw an XBee exception when sending and checking any SMS packet.
+		Mockito.doThrow(new XBeeException()).when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(false));
+		
+		cellularDevice.sendSMS(PHONE, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.CellularDevice#sendSMS(String, String)}.
+	 * 
+	 * <p>Verify that SMS is sent successfully if there is not any error when sending and checking the SMS packet.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test
+	public void testSendSMSSuccess() throws TimeoutException, XBeeException {
+		// Do nothing when sending and checking any SMS packet.
+		Mockito.doNothing().when(cellularDevice).sendAndCheckXBeePacket(Mockito.any(TXSMSPacket.class), Mockito.eq(false));
+		
+		cellularDevice.sendSMS(PHONE, DATA);
+		
+		// Verify the sendAndCheckXBeePacket(XBeePacket, boolean) method was called.
+		Mockito.verify(cellularDevice, Mockito.times(1)).sendAndCheckXBeePacket(Mockito.eq(smsPacket), Mockito.eq(false));
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/WLANDeviceReadDataTest.java
+++ b/library/src/test/java/com/digi/xbee/api/WLANDeviceReadDataTest.java
@@ -1,0 +1,407 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.digi.xbee.api.connection.DataReader;
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.models.IP32BitAddress;
+import com.digi.xbee.api.models.NetworkMessage;
+import com.digi.xbee.api.models.NetworkProtocol;
+import com.digi.xbee.api.models.OperatingMode;
+import com.digi.xbee.api.models.XBeePacketsQueue;
+import com.digi.xbee.api.packet.XBeePacket;
+import com.digi.xbee.api.packet.network.RXIPv4Packet;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({WLANDevice.class, DataReader.class})
+public class WLANDeviceReadDataTest {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+	
+	// Variables.
+	private WLANDevice wlanDevice;
+	
+	private SerialPortRxTx mockConnectionInterface;
+	
+	private XBeePacketsQueue mockXBeePacketsQueue;
+	
+	private IP32BitAddress ipAddress;
+	private String receivedNetworkData;
+	
+	private int sourcePort = 123;
+	private int destPort = 456;
+	
+	private NetworkProtocol protocol = NetworkProtocol.TCP;
+	
+	@Before
+	public void setUp() throws Exception {
+		ipAddress = new IP32BitAddress("10.101.1.123");
+		receivedNetworkData = "Received network data";
+		
+		mockConnectionInterface = Mockito.mock(SerialPortRxTx.class);
+		
+		Mockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Mockito.when(mockConnectionInterface.isOpen()).thenReturn(true);
+				return null;
+			}
+		}).when(mockConnectionInterface).open();
+		
+		Mockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Mockito.when(mockConnectionInterface.isOpen()).thenReturn(false);
+				return null;
+			}
+		}).when(mockConnectionInterface).close();
+		
+		mockXBeePacketsQueue = Mockito.mock(XBeePacketsQueue.class);
+		
+		Mockito.doAnswer(new Answer<XBeePacket>() {
+			public XBeePacket answer(InvocationOnMock invocation) throws Exception {
+				return new RXIPv4Packet(ipAddress, destPort, sourcePort,
+						protocol, receivedNetworkData.getBytes());
+			}
+		}).when(mockXBeePacketsQueue).getFirstNetworkDataPacketFrom(Mockito.any(IP32BitAddress.class), Mockito.anyInt());
+		
+		Mockito.doAnswer(new Answer<XBeePacket>() {
+			public XBeePacket answer(InvocationOnMock invocation) throws Exception {
+				return new RXIPv4Packet(ipAddress, destPort, sourcePort,
+						protocol, receivedNetworkData.getBytes());
+			}
+		}).when(mockXBeePacketsQueue).getFirstNetworkDataPacket(Mockito.anyInt());
+		
+		PowerMockito.whenNew(XBeePacketsQueue.class).withAnyArguments().thenReturn(mockXBeePacketsQueue);
+		
+		wlanDevice = PowerMockito.spy(new WLANDevice(mockConnectionInterface));
+		
+		Mockito.doReturn(OperatingMode.API).when(wlanDevice).determineOperatingMode();
+		Mockito.doNothing().when(wlanDevice).readDeviceInfo();
+		
+		wlanDevice.open();
+	}
+	
+	@After
+	public void tearDown() throws Exception {
+		wlanDevice.close();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkData()}.
+	 */
+	@Test
+	public final void testReadNetworkDataInterfaceNotOpenException() {
+		// Setup the resources for the test.
+		Mockito.when(wlanDevice.isOpen()).thenReturn(false);
+		
+		exception.expect(InterfaceNotOpenException.class);
+		exception.expectMessage(is(equalTo("The connection interface is not open.")));
+		
+		// Call the method under test and verify the result.
+		wlanDevice.readNetworkData();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetowrkData()}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetowrkData() throws Exception {
+		// Call the method under test.
+		NetworkMessage readMessage = wlanDevice.readNetworkData();
+		
+		// Verify the result.
+		PowerMockito.verifyPrivate(wlanDevice).invoke("readNetworkDataPacket", null, 3000);
+		
+		assertThat("IP address must not be null", readMessage.getIPAddress(), is(not(equalTo(null))));
+		assertThat("IP address must be '" + ipAddress + "' and not '" + readMessage.getIPAddress() + "'", readMessage.getIPAddress(), is(equalTo(ipAddress)));
+		assertThat("Source port must be '" + sourcePort + "' and not '" + readMessage.getSourcePort(), readMessage.getSourcePort(), is(equalTo(sourcePort)));
+		assertThat("Destination port must be '" + destPort + "' and not '" + readMessage.getSourcePort(), readMessage.getDestPort(), is(equalTo(destPort)));
+		assertThat("Protocol port must be '" + protocol.getName() + "' and not '" + readMessage.getProtocol().getName(), readMessage.getProtocol(), is(equalTo(protocol)));
+		assertThat("Received data must be '" + receivedNetworkData + "' and not '" + readMessage.getDataString() + "'", readMessage.getDataString(), is(equalTo(receivedNetworkData)));
+		assertThat("Receive message must not be broadcast", readMessage.isBroadcast(), is(equalTo(false)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkData(int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataTimeoutNegative() throws Exception {
+		// Setup the resources for the test.
+		int timeout = -100;
+		NetworkMessage message = new NetworkMessage(ipAddress, sourcePort, destPort, protocol, new byte[0]);
+		PowerMockito.doReturn(message).when(wlanDevice, "readNetworkDataPacket", null, timeout);
+		
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(is(equalTo("Read timeout must be 0 or greater.")));
+		
+		// Call the method under test and verify the result.
+		wlanDevice.readNetworkData(timeout);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkData(int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataTimeout() throws Exception {
+		// Setup the resources for the test.
+		int timeout = 100;
+		
+		// Call the method under test.
+		NetworkMessage readMessage = wlanDevice.readNetworkData(timeout);
+		
+		// Verify the result.
+		PowerMockito.verifyPrivate(wlanDevice).invoke("readNetworkDataPacket", null, timeout);
+		
+		assertThat("IP address must not be null", readMessage.getIPAddress(), is(not(equalTo(null))));
+		assertThat("IP address must be '" + ipAddress + "' and not '" + readMessage.getIPAddress() + "'", readMessage.getIPAddress(), is(equalTo(ipAddress)));
+		assertThat("Source port must be '" + sourcePort + "' and not '" + readMessage.getSourcePort(), readMessage.getSourcePort(), is(equalTo(sourcePort)));
+		assertThat("Destination port must be '" + destPort + "' and not '" + readMessage.getSourcePort(), readMessage.getDestPort(), is(equalTo(destPort)));
+		assertThat("Protocol port must be '" + protocol.getName() + "' and not '" + readMessage.getProtocol().getName(), readMessage.getProtocol(), is(equalTo(protocol)));
+		assertThat("Received data must be '" + receivedNetworkData + "' and not '" + readMessage.getDataString() + "'", readMessage.getDataString(), is(equalTo(receivedNetworkData)));
+		assertThat("Receive message must not be broadcast", readMessage.isBroadcast(), is(equalTo(false)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataFrom(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataFromNullIP() throws Exception {
+		// Setup the resources for the test.
+		exception.expect(NullPointerException.class);
+		exception.expectMessage(is(equalTo("IP address cannot be null.")));
+
+		// Call the method under test and verify the result.
+		wlanDevice.readNetworkDataFrom(null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataFrom(IP32BitAddress))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataFrom() throws Exception {
+		// Call the method under test.
+		NetworkMessage readMessage = wlanDevice.readNetworkDataFrom(ipAddress);
+
+		// Verify the result.
+		PowerMockito.verifyPrivate(wlanDevice).invoke("readNetworkDataPacket", ipAddress, 3000);
+		
+		assertThat("IP address must not be null", readMessage.getIPAddress(), is(not(equalTo(null))));
+		assertThat("IP address must be '" + ipAddress + "' and not '" + readMessage.getIPAddress() + "'", readMessage.getIPAddress(), is(equalTo(ipAddress)));
+		assertThat("Source port must be '" + sourcePort + "' and not '" + readMessage.getSourcePort(), readMessage.getSourcePort(), is(equalTo(sourcePort)));
+		assertThat("Destination port must be '" + destPort + "' and not '" + readMessage.getSourcePort(), readMessage.getDestPort(), is(equalTo(destPort)));
+		assertThat("Protocol port must be '" + protocol.getName() + "' and not '" + readMessage.getProtocol().getName(), readMessage.getProtocol(), is(equalTo(protocol)));
+		assertThat("Received data must be '" + receivedNetworkData + "' and not '" + readMessage.getDataString() + "'", readMessage.getDataString(), is(equalTo(receivedNetworkData)));
+		assertThat("Receive message must not be broadcast", readMessage.isBroadcast(), is(equalTo(false)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataFrom(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataFromTimeoutNegative() throws Exception {
+		// Setup the resources for the test.
+		int timeout = -100;
+		
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(is(equalTo("Read timeout must be 0 or greater.")));
+
+		// Call the method under test and verify the result.
+		wlanDevice.readNetworkDataFrom(ipAddress, timeout);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataFrom(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataFromTimeoutNullIP() throws Exception {
+		// Setup the resources for the test.
+		exception.expect(NullPointerException.class);
+		exception.expectMessage(is(equalTo("IP address cannot be null.")));
+
+		// Call the method under test and verify the result.
+		wlanDevice.readNetworkDataFrom(null, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataFrom(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataFromTimeout() throws Exception {
+		// Setup the resources for the test.
+		int timeout = 100;
+		
+		// Call the method under test.
+		NetworkMessage readMessage = wlanDevice.readNetworkDataFrom(ipAddress, timeout);
+		
+		// Verify the result.
+		PowerMockito.verifyPrivate(wlanDevice).invoke("readNetworkDataPacket", ipAddress, timeout);
+		
+		assertThat("IP address must not be null", readMessage.getIPAddress(), is(not(equalTo(null))));
+		assertThat("IP address must be '" + ipAddress + "' and not '" + readMessage.getIPAddress() + "'", readMessage.getIPAddress(), is(equalTo(ipAddress)));
+		assertThat("Source port must be '" + sourcePort + "' and not '" + readMessage.getSourcePort(), readMessage.getSourcePort(), is(equalTo(sourcePort)));
+		assertThat("Destination port must be '" + destPort + "' and not '" + readMessage.getSourcePort(), readMessage.getDestPort(), is(equalTo(destPort)));
+		assertThat("Protocol port must be '" + protocol.getName() + "' and not '" + readMessage.getProtocol().getName(), readMessage.getProtocol(), is(equalTo(protocol)));
+		assertThat("Received data must be '" + receivedNetworkData + "' and not '" + readMessage.getDataString() + "'", readMessage.getDataString(), is(equalTo(receivedNetworkData)));
+		assertThat("Receive message must not be broadcast", readMessage.isBroadcast(), is(equalTo(false)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataPacket(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataPacketInterfaceNotOpenException() throws Exception {
+		// Setup the resources for the test.
+		Mockito.when(wlanDevice.isOpen()).thenReturn(false);
+		
+		exception.expect(InterfaceNotOpenException.class);
+		exception.expectMessage(is(equalTo("The connection interface is not open.")));
+		
+		// Call the method under test and verify the result.
+		Whitebox.invokeMethod(wlanDevice, "readNetworkDataPacket", (IP32BitAddress)null, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataPacket(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataPacketNotIPTimeout() throws Exception {
+		// Setup the resources for the test.
+		Mockito.doAnswer(new Answer<XBeePacket>() {
+			public XBeePacket answer(InvocationOnMock invocation) throws Exception {
+				return null;
+			}
+		}).when(mockXBeePacketsQueue).getFirstNetworkDataPacket(Mockito.anyInt());
+		
+		// Call the method under test.
+		NetworkMessage message = Whitebox.invokeMethod(wlanDevice, "readNetworkDataPacket", (IP32BitAddress)null, 100);
+		
+		// Verify the result.
+		assertThat("Message must be null", message, is(equalTo(null)));
+		
+		Mockito.verify(mockXBeePacketsQueue).getFirstNetworkDataPacket(100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataPacket(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataPacketNotIP() throws Exception {
+		// Setup the resources for the test.
+		receivedNetworkData = "Received message data";
+		
+		// Call the method under test.
+		NetworkMessage readMessage = Whitebox.invokeMethod(wlanDevice, "readNetworkDataPacket", (IP32BitAddress)null, 100);
+		
+		// Verify the result.
+		assertThat("Message must not be null", readMessage, is(not(equalTo(null))));
+		assertThat("IP address must not be null", readMessage.getIPAddress(), is(not(equalTo(null))));
+		assertThat("IP address must be '" + ipAddress + "' and not '" + readMessage.getIPAddress() + "'", readMessage.getIPAddress(), is(equalTo(ipAddress)));
+		assertThat("Source port must be '" + sourcePort + "' and not '" + readMessage.getSourcePort(), readMessage.getSourcePort(), is(equalTo(sourcePort)));
+		assertThat("Destination port must be '" + destPort + "' and not '" + readMessage.getSourcePort(), readMessage.getDestPort(), is(equalTo(destPort)));
+		assertThat("Protocol port must be '" + protocol.getName() + "' and not '" + readMessage.getProtocol().getName(), readMessage.getProtocol(), is(equalTo(protocol)));
+		assertThat("Received data must be '" + receivedNetworkData + "' and not '" + readMessage.getDataString() + "'", readMessage.getDataString(), is(equalTo(receivedNetworkData)));
+		assertThat("Receive message must not be broadcast", readMessage.isBroadcast(), is(equalTo(false)));
+		
+		Mockito.verify(mockXBeePacketsQueue).getFirstNetworkDataPacket(100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetowrkDataPacket(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataPacketWithIPTimeout() throws Exception {
+		Mockito.doAnswer(new Answer<XBeePacket>() {
+			public XBeePacket answer(InvocationOnMock invocation) throws Exception {
+				return null;
+			}
+		}).when(mockXBeePacketsQueue).getFirstNetworkDataPacketFrom(Mockito.eq(ipAddress), Mockito.anyInt());
+		
+		// Call the method under test.
+		NetworkMessage message = Whitebox.invokeMethod(wlanDevice, "readNetworkDataPacket", ipAddress, 100);
+		
+		// Verify the result.
+		assertThat("Message must be null", message, is(equalTo(null)));
+		
+		Mockito.verify(mockXBeePacketsQueue).getFirstNetworkDataPacketFrom(ipAddress, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#readNetworkDataPacket(IP32BitAddress, int))}.
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testReadNetworkDataPacketWithIP() throws Exception {
+		// Setup the resources for the test.
+		receivedNetworkData = "Received message data";
+		
+		// Call the method under test.
+		NetworkMessage readMessage = Whitebox.invokeMethod(wlanDevice, "readNetworkDataPacket", ipAddress, 100);
+		
+		// Verify the result.
+		assertThat("Message must not be null", readMessage, is(not(equalTo(null))));
+		assertThat("Message must not be null", readMessage, is(not(equalTo(null))));
+		assertThat("IP address must not be null", readMessage.getIPAddress(), is(not(equalTo(null))));
+		assertThat("IP address must be '" + ipAddress + "' and not '" + readMessage.getIPAddress() + "'", readMessage.getIPAddress(), is(equalTo(ipAddress)));
+		assertThat("Source port must be '" + sourcePort + "' and not '" + readMessage.getSourcePort(), readMessage.getSourcePort(), is(equalTo(sourcePort)));
+		assertThat("Destination port must be '" + destPort + "' and not '" + readMessage.getSourcePort(), readMessage.getDestPort(), is(equalTo(destPort)));
+		assertThat("Protocol port must be '" + protocol.getName() + "' and not '" + readMessage.getProtocol().getName(), readMessage.getProtocol(), is(equalTo(protocol)));
+		assertThat("Received data must be '" + receivedNetworkData + "' and not '" + readMessage.getDataString() + "'", readMessage.getDataString(), is(equalTo(receivedNetworkData)));
+		assertThat("Receive message must not be broadcast", readMessage.isBroadcast(), is(equalTo(false)));
+		
+		Mockito.verify(mockXBeePacketsQueue).getFirstNetworkDataPacketFrom(ipAddress, 100);
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/WLANDeviceTest.java
+++ b/library/src/test/java/com/digi/xbee/api/WLANDeviceTest.java
@@ -27,7 +27,13 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.XBeeException;
 import com.digi.xbee.api.models.IP32BitAddress;
+import com.digi.xbee.api.models.NetworkProtocol;
+import com.digi.xbee.api.utils.ByteUtils;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({WLANDevice.class})
@@ -35,7 +41,13 @@ public class WLANDeviceTest {
 	
 	// Constants.
 	private static final String PARAMETER_MY = "MY";
+	private static final String PARAMETER_C0 = "C0";
 	private static final byte[] RESPONSE_MY = new byte[]{0x00, 0x00, 0x00, 0x00};
+	private static final byte[] RESPONSE_C0 = new byte[]{0x12, 0x34};
+	
+	private static short EXPECTED_SOURCE_PORT = ByteUtils.byteArrayToShort(RESPONSE_C0);
+	
+	private static NetworkProtocol PROTOCOL = NetworkProtocol.UDP;
 	
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
@@ -75,9 +87,13 @@ public class WLANDeviceTest {
 		
 		// Return a valid response when requesting the MY parameter value.
 		Mockito.doReturn(RESPONSE_MY).when(wlanDevice).getParameter(PARAMETER_MY);
+		// Return a valid response when requesting the C0 parameter value.
+		Mockito.doReturn(RESPONSE_C0).when(wlanDevice).getParameter(PARAMETER_C0);
 		
 		// Fist, check that the IP is null (it has not been created yet)
 		assertNull(wlanDevice.getIPAddress());
+		// Check that the source port is the default one.
+		assertEquals(WLANDevice.DEFAULT_SOURCE_PORT, wlanDevice.sourcePort);
 		
 		// Call the readDeviceInfo method.
 		wlanDevice.readDeviceInfo();
@@ -85,6 +101,230 @@ public class WLANDeviceTest {
 		
 		// Verify that the IP address was generated.
 		assertEquals(ipAddress, wlanDevice.getIPAddress());
+		// Verify that the source port is the expected one.
+		assertEquals(EXPECTED_SOURCE_PORT, wlanDevice.sourcePort);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#setNetworkProtocol(com.digi.xbee.api.models.NetworkProtocol)}.
+	 * 
+	 * Verify that network protocol cannot be set if it is {@code null}.
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testSetNetworkProtocolNullProtocol() {
+		wlanDevice.setNetworkProtocol(null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#setNetworkProtocol(com.digi.xbee.api.models.NetworkProtocol)}.
+	 * 
+	 * Verify that network protocol can be set successfully {@code null}.
+	 */
+	@Test
+	public void testSetNetworkProtocolSuccess() {
+		// Verify the device has the default network protocol.
+		assertEquals(WLANDevice.DEFAULT_PROTOCOL, wlanDevice.protocol);
+		
+		// Set the new protocol and verify it was set correctly.
+		wlanDevice.setNetworkProtocol(PROTOCOL);
+		assertEquals(PROTOCOL, wlanDevice.getNetworkProtocol());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#startListening(int)}.
+	 * 
+	 * <p>Verify that device cannot start listening for network data if the 
+	 * source port is bigger than 65535.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testStartListeningInvalidPortBig() throws TimeoutException, XBeeException {
+		wlanDevice.startListening(100000);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#startListening(int)}.
+	 * 
+	 * <p>Verify that device cannot start listening for network data if the 
+	 * source port is negative.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testStartListeningInvalidPortNegative() throws TimeoutException, XBeeException {
+		wlanDevice.startListening(-10);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#startListening(int)}.
+	 * 
+	 * <p>Verify that device cannot start listening for network data if the 
+	 * device is not open.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public void testStartListeningConnectionClosed() throws TimeoutException, XBeeException {
+		// Throw an Interface not open exception when setting any parameter.
+		Mockito.doThrow(new InterfaceNotOpenException()).when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		wlanDevice.startListening(123);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#startListening(int)}.
+	 * 
+	 * <p>Verify that device cannot start listening for network data if device 
+	 * has an invalid operating mode.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public void testStartListeningInvalidOperatingMode() throws TimeoutException, XBeeException {
+		// Throw an Invalid operating mode exception when setting any parameter.
+		Mockito.doThrow(new InvalidOperatingModeException()).when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		wlanDevice.startListening(123);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#startListening(int)}.
+	 * 
+	 * <p>Verify that device cannot start listening for network data if there 
+	 * is a timeout setting the 'C0' parameter.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public void testStartListeningTimeout() throws TimeoutException, XBeeException {
+		// Throw an timeout exception when setting any parameter.
+		Mockito.doThrow(new TimeoutException()).when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		wlanDevice.startListening(123);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#startListening(int)}.
+	 * 
+	 * <p>Verify that device starts listening for network data successfully.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test
+	public void testStartListeningSuccess() throws TimeoutException, XBeeException {
+		int newSourcePort = 123;
+		// Do nothing when setting any parameter.
+		Mockito.doNothing().when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		wlanDevice.startListening(newSourcePort);
+		
+		// Verify that source port has changed to the provided one.
+		assertEquals(newSourcePort, wlanDevice.sourcePort);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#stopListening()}.
+	 * 
+	 * <p>Verify that device cannot stop listening for network data if the 
+	 * device is not open.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public void testStopListeningConnectionClosed() throws TimeoutException, XBeeException {
+		// Throw an Interface not open exception when setting any parameter.
+		Mockito.doThrow(new InterfaceNotOpenException()).when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		wlanDevice.stopListening();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#stopListening()}.
+	 * 
+	 * <p>Verify that device cannot stop listening for network data if device 
+	 * has an invalid operating mode.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public void testStopListeningInvalidOperatingMode() throws TimeoutException, XBeeException {
+		// Throw an Invalid operating mode exception when setting any parameter.
+		Mockito.doThrow(new InvalidOperatingModeException()).when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		wlanDevice.stopListening();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#stopListening()}.
+	 * 
+	 * <p>Verify that device cannot stop listening for network data if there 
+	 * is a timeout setting the 'C0' parameter.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public void testStoptListeningTimeout() throws TimeoutException, XBeeException {
+		// Throw an timeout exception when setting any parameter.
+		Mockito.doThrow(new TimeoutException()).when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		wlanDevice.stopListening();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#stopListening()}.
+	 * 
+	 * <p>Verify that device stops listening for network data successfully.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test
+	public void testStopListeningSuccess() throws TimeoutException, XBeeException {
+		// Do nothing when setting tany parameter.
+		Mockito.doNothing().when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		wlanDevice.stopListening();
+		
+		// Verify that source port has changed to 0.
+		assertEquals(0, wlanDevice.sourcePort);
+		
+		// Verify the setParameter(String, byte[]) method was called once.
+		Mockito.verify(wlanDevice, Mockito.times(1)).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WLANDevice#stopListening()}.
+	 * 
+	 * <p>Verify that device stops listening for network data successfully.</p>
+	 * 
+	 * @throws XBeeException 
+	 * @throws TimeoutException 
+	 */
+	@Test
+	public void testStopListeningUDPSuccess() throws TimeoutException, XBeeException {
+		// Do nothing when setting tany parameter.
+		Mockito.doNothing().when(wlanDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		// Return UDP when asked for the network protocol.
+		Mockito.doReturn(NetworkProtocol.UDP).when(wlanDevice).getNetworkProtocol();
+		
+		wlanDevice.stopListening();
+		
+		// Verify that source port has changed to 0.
+		assertEquals(0, wlanDevice.sourcePort);
+		
+		// Verify the setParameter(String, byte[]) method was called twice (one for 'C0' and other for 'DE').
+		Mockito.verify(wlanDevice, Mockito.times(1)).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
 	}
 	
 	/**

--- a/library/src/test/java/com/digi/xbee/api/listeners/INetworkDataReceiveListenerTest.java
+++ b/library/src/test/java/com/digi/xbee/api/listeners/INetworkDataReceiveListenerTest.java
@@ -1,0 +1,349 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.listeners;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.digi.xbee.api.XBeeDevice;
+import com.digi.xbee.api.connection.DataReader;
+import com.digi.xbee.api.connection.IConnectionInterface;
+import com.digi.xbee.api.models.IP32BitAddress;
+import com.digi.xbee.api.models.NetworkMessage;
+import com.digi.xbee.api.models.NetworkProtocol;
+import com.digi.xbee.api.models.OperatingMode;
+import com.digi.xbee.api.packet.APIFrameType;
+import com.digi.xbee.api.packet.XBeePacket;
+import com.digi.xbee.api.packet.common.ATCommandResponsePacket;
+import com.digi.xbee.api.packet.network.RXIPv4Packet;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DataReader.class})
+public class INetworkDataReceiveListenerTest {
+	
+	// Constants.
+	private static final IP32BitAddress IP_ADDRESS = new IP32BitAddress("10.10.2.123");
+	
+	private static final int SOURCE_PORT = 123;
+	private static final int DEST_PORT = 456;
+	
+	private static final NetworkProtocol PROTOCOL = NetworkProtocol.TCP;
+	
+	private static final String RECEIVED_DATA = "data";
+	private static final byte[] RECEIVED_DATA_BYTES = RECEIVED_DATA.getBytes();
+	
+	private static final String PACKET_RECEIVED_METHOD = "packetReceived";
+	private static final String NOTIFY_DATA_RECEIVED_METHOD = "notifyNetworkDataReceived";
+	
+	// Variables.
+	private static XBeeDevice xbeeDevice;
+	
+	private MyReceiveListener receiveNetworkDataListener;
+	
+	private static RXIPv4Packet rxIPv4Packet;
+	private static ATCommandResponsePacket invalidPacket;
+	
+	private DataReader dataReader;
+	
+	@BeforeClass
+	public static void setupOnce() throws Exception {
+		// Mock RX IPV4 Packet.
+		rxIPv4Packet = Mockito.mock(RXIPv4Packet.class);
+		Mockito.when(rxIPv4Packet.getFrameType()).thenReturn(APIFrameType.RX_IPV4);
+		Mockito.when(rxIPv4Packet.getSourcePort()).thenReturn(SOURCE_PORT);
+		Mockito.when(rxIPv4Packet.getDestPort()).thenReturn(DEST_PORT);
+		Mockito.when(rxIPv4Packet.getProtocol()).thenReturn(PROTOCOL);
+		Mockito.when(rxIPv4Packet.getData()).thenReturn(RECEIVED_DATA_BYTES);
+		Mockito.when(rxIPv4Packet.getDestAddress()).thenReturn(IP_ADDRESS);
+		Mockito.when(rxIPv4Packet.isBroadcast()).thenReturn(false);
+		
+		// Mock an invalid packet.
+		invalidPacket = Mockito.mock(ATCommandResponsePacket.class);
+		
+		// Mock the XBee device.
+		xbeeDevice = Mockito.mock(XBeeDevice.class);
+	}
+	
+	@Before
+	public void setup() throws Exception {
+		// Data receive listener.
+		receiveNetworkDataListener = PowerMockito.spy(new MyReceiveListener());
+		
+		// Data reader.
+		dataReader = PowerMockito.spy(new DataReader(Mockito.mock(IConnectionInterface.class), OperatingMode.UNKNOWN, xbeeDevice));
+		// Stub the 'notifyDataReceived' method of the dataReader instance so it directly notifies the 
+		// listeners instead of opening a new thread per listener (which is what the real method does). This avoids us 
+		// having to wait for the executor to run the threads.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) {
+				Object[] args = invocation.getArguments();
+				NetworkMessage networkMessage = (NetworkMessage)args[0];
+				notifyDataReceiveListeners(networkMessage);
+				return null;
+			}
+		}).when(dataReader, NOTIFY_DATA_RECEIVED_METHOD, Mockito.any(NetworkMessage.class));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.INetworkDataReceiveListener#networkDataReceived(NetworkMessage)}.
+	 * 
+	 * <p>Verify that the network data received callback of the INetworkDataReceiveListener interface
+	 * is executed correctly when a unicast NetworkMessage (originated by an RXIPV4 frame) is
+	 * received.</p>
+	 */
+	@Test
+	public void testUnicastDataReceiveEvent() {
+		// This is the message that should have been created if an RXIPV4 frame would have been received.
+		NetworkMessage networkMessage = new NetworkMessage(IP_ADDRESS, SOURCE_PORT, DEST_PORT, PROTOCOL, RECEIVED_DATA_BYTES, false);
+		
+		receiveNetworkDataListener.networkDataReceived(networkMessage);
+		
+		assertEquals(IP_ADDRESS, receiveNetworkDataListener.getIPAddress());
+		assertEquals(SOURCE_PORT, receiveNetworkDataListener.getSourcePort());
+		assertEquals(DEST_PORT, receiveNetworkDataListener.getDestPort());
+		assertEquals(PROTOCOL, receiveNetworkDataListener.getProtocol());
+		assertArrayEquals(RECEIVED_DATA_BYTES, receiveNetworkDataListener.getData());
+		assertFalse(receiveNetworkDataListener.isBroadcast());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.INetworkDataReceiveListener#networkDataReceived(NetworkMessage)}.
+	 * 
+	 * <p>Verify that the network data received callback of the INetworkDataReceiveListener interface
+	 * is executed correctly when a broadcast NetworkMessage (originated by an RXIPV4 frame) is
+	 * received.</p>
+	 */
+	@Test
+	public void testBroadcastDataReceiveEvent() {
+		// This is the message that should have been created if an RXIPV4 frame would have been received.
+		NetworkMessage networkMessage = new NetworkMessage(IP_ADDRESS, SOURCE_PORT, DEST_PORT, PROTOCOL, RECEIVED_DATA_BYTES, true);
+		
+		receiveNetworkDataListener.networkDataReceived(networkMessage);
+		
+		assertEquals(IP_ADDRESS, receiveNetworkDataListener.getIPAddress());
+		assertEquals(SOURCE_PORT, receiveNetworkDataListener.getSourcePort());
+		assertEquals(DEST_PORT, receiveNetworkDataListener.getDestPort());
+		assertEquals(PROTOCOL, receiveNetworkDataListener.getProtocol());
+		assertArrayEquals(RECEIVED_DATA_BYTES, receiveNetworkDataListener.getData());
+		assertTrue(receiveNetworkDataListener.isBroadcast());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.INetworkDataReceiveListener#networkDataReceived(NetworkMessage)} and
+	 * {@link com.digi.xbee.api.connection.DataReader#packetReceived(XBeePacket)}.
+	 * 
+	 * <p>Verify that if the listener is not subscribed to receive network data, the callback 
+	 * is not executed although a data packet is received.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testDataReceiveNotSubscribed() throws Exception {
+		// Whenever a new IP address needs to be instantiated, return the constant one.
+		PowerMockito.whenNew(IP32BitAddress.class).withAnyArguments().thenReturn(IP_ADDRESS);
+		
+		// Fire the private packetReceived method of the dataReader with an RXIPV4Packet packet.
+		Whitebox.invokeMethod(dataReader, PACKET_RECEIVED_METHOD, rxIPv4Packet);
+		
+		// Verify that the notifyNetworkDataReceived private method was called.
+		PowerMockito.verifyPrivate(dataReader, Mockito.times(1)).invoke(NOTIFY_DATA_RECEIVED_METHOD, 
+				Mockito.any(NetworkMessage.class));
+		
+		// As the receiveNetworkDataListener was not subscribed in the networkDataReceiveListeners of 
+		// the dataReader object, the IP address and data of the receiveNetworkDataListener should be null.
+		assertNull(receiveNetworkDataListener.getIPAddress());
+		assertEquals(-1, receiveNetworkDataListener.getSourcePort());
+		assertEquals(-1, receiveNetworkDataListener.getDestPort());
+		assertNull(receiveNetworkDataListener.getProtocol());
+		assertNull(receiveNetworkDataListener.getData());
+		assertFalse(receiveNetworkDataListener.isBroadcast());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.INetworkDataReceiveListener#networkDataReceived(NetworkMessage)} and
+	 * {@link com.digi.xbee.api.connection.DataReader#packetReceived(XBeePacket)}.
+	 * 
+	 * <p>Verify that, when subscribed to receive network data and an RXIPV4 packet is received,
+	 * the callback of the listener is executed.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testDataReceiveSubscribedReceive() throws Exception {
+		// Whenever a new IP address needs to be instantiated, return the constant one.
+		PowerMockito.whenNew(IP32BitAddress.class).withAnyArguments().thenReturn(IP_ADDRESS);
+		
+		// Subscribe to listen for network data.
+		dataReader.addNetworkDataReceiveListener(receiveNetworkDataListener);
+		
+		// Fire the private packetReceived method of the dataReader with an RXIPV4 packet.
+		Whitebox.invokeMethod(dataReader, PACKET_RECEIVED_METHOD, rxIPv4Packet);
+		
+		// Verify that the notifyNetworkDataReceived private method was called.
+		PowerMockito.verifyPrivate(dataReader, Mockito.times(1)).invoke(NOTIFY_DATA_RECEIVED_METHOD, 
+				Mockito.any(NetworkMessage.class));
+		
+		// Verify that the networkDataReceived method of the listener was executed one time.
+		Mockito.verify(receiveNetworkDataListener, Mockito.times(1)).networkDataReceived(Mockito.any(NetworkMessage.class));
+		
+		// All the parameters of our listener should be correct.
+		assertEquals(IP_ADDRESS, receiveNetworkDataListener.getIPAddress());
+		assertEquals(SOURCE_PORT, receiveNetworkDataListener.getSourcePort());
+		assertEquals(DEST_PORT, receiveNetworkDataListener.getDestPort());
+		assertEquals(PROTOCOL, receiveNetworkDataListener.getProtocol());
+		assertArrayEquals(RECEIVED_DATA_BYTES, receiveNetworkDataListener.getData());
+		assertFalse(receiveNetworkDataListener.isBroadcast());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.INetworkDataReceiveListener#networkDataReceived(NetworkMessage)} and
+	 * {@link com.digi.xbee.api.connection.DataReader#packetReceived(XBeePacket)}.
+	 * 
+	 * <p>Verify that, when subscribed to receive network data and a packet that does not 
+	 * correspond to network data is received, the callback of the listener is not executed.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testDataReceiveSubscribedInvalid() throws Exception {
+		// Subscribe to listen for network data.
+		dataReader.addNetworkDataReceiveListener(receiveNetworkDataListener);
+		
+		// Fire the private packetReceived method of the dataReader with an invalid packet.
+		Whitebox.invokeMethod(dataReader, PACKET_RECEIVED_METHOD, invalidPacket);
+		
+		// Verify that the notifyNetworkDataReceived private method was not called.
+		PowerMockito.verifyPrivate(dataReader, Mockito.never()).invoke(NOTIFY_DATA_RECEIVED_METHOD, 
+				Mockito.any(NetworkMessage.class));
+		
+		// Verify that the callback of the listener was not executed
+		Mockito.verify(receiveNetworkDataListener, Mockito.never()).networkDataReceived(Mockito.any(NetworkMessage.class));
+		
+		// All the parameters of our listener should be empty.
+		assertNull(receiveNetworkDataListener.getIPAddress());
+		assertEquals(-1, receiveNetworkDataListener.getSourcePort());
+		assertEquals(-1, receiveNetworkDataListener.getDestPort());
+		assertNull(receiveNetworkDataListener.getProtocol());
+		assertNull(receiveNetworkDataListener.getData());
+		assertFalse(receiveNetworkDataListener.isBroadcast());
+	}
+	
+	/**
+	 * This method directly notifies the INetworkDataReceiveListeners of the dataReader instance 
+	 * that new network data has been received. This method intends to replace the original 
+	 * 'notifyNetworkDataReceived' located within the dataReader object because it generates a 
+	 * thread for each notify process.
+	 * 
+	 * @param networkMessage The NetworkMessage containing the IP address that sent the data, the data 
+	 *                       and a flag indicating if the data was sent via broadcast.
+	 */
+	private void notifyDataReceiveListeners(NetworkMessage networkMessage) {
+		@SuppressWarnings("unchecked")
+		ArrayList<INetworkDataReceiveListener> networkDataReceiveListeners = (ArrayList<INetworkDataReceiveListener>)Whitebox.getInternalState(dataReader, "networkDataReceiveListeners");
+		for (INetworkDataReceiveListener listener:networkDataReceiveListeners)
+			listener.networkDataReceived(networkMessage);
+	}
+	
+	/**
+	 * Helper class to test the INetworkDataReceiveListener.
+	 */
+	private class MyReceiveListener implements INetworkDataReceiveListener {
+		
+		// Variables.
+		private byte[] data = null;
+		private IP32BitAddress ipAddress = null;
+		private int sourcePort = -1;
+		private int destPort = -1;
+		private NetworkProtocol protocol = null;
+		private boolean isBroadcast = false;
+		
+		/*
+		 * (non-Javadoc)
+		 * @see com.digi.xbee.api.listeners.INetworkDataReceiveListener#networkDataReceived(com.digi.xbee.api.models.NetworkMessage)
+		 */
+		public void networkDataReceived(NetworkMessage networkMessage) {
+			this.ipAddress = networkMessage.getIPAddress();
+			this.sourcePort = networkMessage.getSourcePort();
+			this.destPort = networkMessage.getDestPort();
+			this.protocol = networkMessage.getProtocol();
+			this.data = networkMessage.getData();
+			this.isBroadcast = networkMessage.isBroadcast();
+		}
+		
+		/**
+		 * Retrieves the data received.
+		 * 
+		 * @return The data.
+		 */
+		public byte[] getData() {
+			return data;
+		}
+		
+		/**
+		 * Retrieves the IP address that sent the data.
+		 * 
+		 * @return The IP address.
+		 */
+		public IP32BitAddress getIPAddress() {
+			return ipAddress;
+		}
+		
+		/**
+		 * Retrieves the source port of the transmission.
+		 * 
+		 * @return The source port of the transmission.
+		 */
+		public int getSourcePort() {
+			return sourcePort;
+		}
+		
+		/**
+		 * Retrieves the destination port of the transmission.
+		 * 
+		 * @return The destination port of the transmission.
+		 */
+		public int getDestPort() {
+			return destPort;
+		}
+		
+		/**
+		 * Retrieves the protocol of the transmission.
+		 * 
+		 * @return The protocol of the transmission.
+		 */
+		public NetworkProtocol getProtocol() {
+			return protocol;
+		}
+		
+		/**
+		 * Retrieves whether or not the data was sent via broadcast.
+		 * 
+		 * @return True if the data was sent via broadcast, false otherwise.
+		 */
+		public boolean isBroadcast() {
+			return isBroadcast;
+		}
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/listeners/ISMSReceiveListenerTest.java
+++ b/library/src/test/java/com/digi/xbee/api/listeners/ISMSReceiveListenerTest.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.listeners;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.digi.xbee.api.XBeeDevice;
+import com.digi.xbee.api.connection.DataReader;
+import com.digi.xbee.api.connection.IConnectionInterface;
+import com.digi.xbee.api.models.OperatingMode;
+import com.digi.xbee.api.models.SMSMessage;
+import com.digi.xbee.api.packet.APIFrameType;
+import com.digi.xbee.api.packet.XBeePacket;
+import com.digi.xbee.api.packet.cellular.RXSMSPacket;
+import com.digi.xbee.api.packet.common.ATCommandResponsePacket;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DataReader.class})
+public class ISMSReceiveListenerTest {
+	
+	// Constants.
+	private static final String PHONE = "55512345678";
+	private static final String RECEIVED_DATA = "data";
+	
+	private static final String PACKET_RECEIVED_METHOD = "packetReceived";
+	private static final String NOTIFY_DATA_RECEIVED_METHOD = "notifySMSReceived";
+	
+	// Variables.
+	private static XBeeDevice xbeeDevice;
+	
+	private MyReceiveListener receiveSMSListener;
+	
+	private static RXSMSPacket rxSMSPacket;
+	private static ATCommandResponsePacket invalidPacket;
+	
+	private DataReader dataReader;
+	
+	@BeforeClass
+	public static void setupOnce() throws Exception {
+		// Mock RX IPV4 Packet.
+		rxSMSPacket = Mockito.mock(RXSMSPacket.class);
+		Mockito.when(rxSMSPacket.getFrameType()).thenReturn(APIFrameType.RX_SMS);
+		Mockito.when(rxSMSPacket.getData()).thenReturn(RECEIVED_DATA);
+		Mockito.when(rxSMSPacket.getPhoneNumber()).thenReturn(PHONE);
+		Mockito.when(rxSMSPacket.isBroadcast()).thenReturn(false);
+		
+		// Mock an invalid packet.
+		invalidPacket = Mockito.mock(ATCommandResponsePacket.class);
+		
+		// Mock the XBee device.
+		xbeeDevice = Mockito.mock(XBeeDevice.class);
+	}
+	
+	@Before
+	public void setup() throws Exception {
+		// Data receive listener.
+		receiveSMSListener = PowerMockito.spy(new MyReceiveListener());
+		
+		// Data reader.
+		dataReader = PowerMockito.spy(new DataReader(Mockito.mock(IConnectionInterface.class), OperatingMode.UNKNOWN, xbeeDevice));
+		// Stub the 'notifyDataReceived' method of the dataReader instance so it directly notifies the 
+		// listeners instead of opening a new thread per listener (which is what the real method does). This avoids us 
+		// having to wait for the executor to run the threads.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) {
+				Object[] args = invocation.getArguments();
+				SMSMessage smsMessage = (SMSMessage)args[0];
+				notifySMSReceiveListeners(smsMessage);
+				return null;
+			}
+		}).when(dataReader, NOTIFY_DATA_RECEIVED_METHOD, Mockito.any(SMSMessage.class));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.ISMSReceiveListener#smsReceived(SMSMessage)}.
+	 * 
+	 * <p>Verify that the SMS received callback of the ISMSReceiveListener interface
+	 * is executed correctly when a SMSMessage (originated by an RXSMS frame) is
+	 * received.</p>
+	 */
+	@Test
+	public void testBroadcastDataReceiveEvent() {
+		// This is the message that should have been created if an RXSMS frame would have been received.
+		SMSMessage smsMessage = new SMSMessage(PHONE, RECEIVED_DATA);
+		
+		receiveSMSListener.smsReceived(smsMessage);
+		
+		assertEquals(PHONE, receiveSMSListener.getPhone());
+		assertEquals(RECEIVED_DATA, receiveSMSListener.getData());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.ISMSReceiveListener#smsReceived(SMSMessage)} and
+	 * {@link com.digi.xbee.api.connection.DataReader#packetReceived(XBeePacket)}.
+	 * 
+	 * <p>Verify that if the listener is not subscribed to receive SMS, the callback 
+	 * is not executed although an SMS packet is received.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testDataReceiveNotSubscribed() throws Exception {
+		// Fire the private packetReceived method of the dataReader with an RXSMS packet.
+		Whitebox.invokeMethod(dataReader, PACKET_RECEIVED_METHOD, rxSMSPacket);
+		
+		// Verify that the notifySMSReceived private method was called.
+		PowerMockito.verifyPrivate(dataReader, Mockito.times(1)).invoke(NOTIFY_DATA_RECEIVED_METHOD, 
+				Mockito.any(SMSMessage.class));
+		
+		// As the receiveSMSListener was not subscribed in the smsReceiveListeners of 
+		// the dataReader object, the phone number and text of the receiveSMSListener should be null.
+		assertNull(receiveSMSListener.getPhone());
+		assertNull(receiveSMSListener.getData());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.ISMSReceiveListener#smsReceived(SMSMessage)} and
+	 * {@link com.digi.xbee.api.connection.DataReader#packetReceived(XBeePacket)}.
+	 * 
+	 * <p>Verify that, when subscribed to receive SMS and an RXSMS packet is received,
+	 * the callback of the listener is executed.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testDataReceiveSubscribedReceive() throws Exception {
+		// Subscribe to listen for SMS.
+		dataReader.addSMSReceiveListener(receiveSMSListener);
+		
+		// Fire the private packetReceived method of the dataReader with an RXSMS packet.
+		Whitebox.invokeMethod(dataReader, PACKET_RECEIVED_METHOD, rxSMSPacket);
+		
+		// Verify that the notifySMSReceived private method was called.
+		PowerMockito.verifyPrivate(dataReader, Mockito.times(1)).invoke(NOTIFY_DATA_RECEIVED_METHOD, 
+				Mockito.any(SMSMessage.class));
+		
+		// Verify that the smsReceived method of the listener was executed one time.
+		Mockito.verify(receiveSMSListener, Mockito.times(1)).smsReceived(Mockito.any(SMSMessage.class));
+		
+		// All the parameters of our listener should be correct.
+		assertEquals(PHONE, receiveSMSListener.getPhone());
+		assertEquals(RECEIVED_DATA, receiveSMSListener.getData());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.listeners.ISMSReceiveListener#smsReceived(SMSMessage)} and
+	 * {@link com.digi.xbee.api.connection.DataReader#packetReceived(XBeePacket)}.
+	 * 
+	 * <p>Verify that, when subscribed to receive SMS and a packet that does not 
+	 * correspond to SMS is received, the callback of the listener is not executed.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testDataReceiveSubscribedInvalid() throws Exception {
+		// Subscribe to listen for SMS.
+		dataReader.addSMSReceiveListener(receiveSMSListener);
+		
+		// Fire the private packetReceived method of the dataReader with an invalid packet.
+		Whitebox.invokeMethod(dataReader, PACKET_RECEIVED_METHOD, invalidPacket);
+		
+		// Verify that the notifySMSReceived private method was not called.
+		PowerMockito.verifyPrivate(dataReader, Mockito.never()).invoke(NOTIFY_DATA_RECEIVED_METHOD, 
+				Mockito.any(SMSMessage.class));
+		
+		// Verify that the callback of the listener was not executed
+		Mockito.verify(receiveSMSListener, Mockito.never()).smsReceived(Mockito.any(SMSMessage.class));
+		
+		// All the parameters of our listener should be empty.
+		assertNull(receiveSMSListener.getPhone());
+		assertNull(receiveSMSListener.getData());
+	}
+	
+	/**
+	 * This method directly notifies the ISMSReceiveListener of the dataReader instance 
+	 * that new a SMS has been received. This method intends to replace the original 
+	 * 'notifySMSReceived' located within the dataReader object because it generates a 
+	 * thread for each notify process.
+	 * 
+	 * @param smsMessage The SMSMessage containing the phone number that sent the SMS and the 
+	 *                   text of the SMS.
+	 */
+	private void notifySMSReceiveListeners(SMSMessage smsMessage) {
+		@SuppressWarnings("unchecked")
+		ArrayList<ISMSReceiveListener> smsReceiveListeners = (ArrayList<ISMSReceiveListener>)Whitebox.getInternalState(dataReader, "smsReceiveListeners");
+		for (ISMSReceiveListener listener:smsReceiveListeners)
+			listener.smsReceived(smsMessage);
+	}
+	
+	/**
+	 * Helper class to test the ISMSReceiveListener.
+	 */
+	private class MyReceiveListener implements ISMSReceiveListener {
+		
+		// Variables.
+		private String data = null;
+		private String phone = null;
+		
+		/*
+		 * (non-Javadoc)
+		 * @see com.digi.xbee.api.listeners.ISMSReceiveListener#smsReceived(com.digi.xbee.api.models.SMSMessage)
+		 */
+		public void smsReceived(SMSMessage smsMessage) {
+			this.phone = smsMessage.getPhoneNumber();
+			this.data = smsMessage.getData();
+		}
+		
+		/**
+		 * Retrieves the data (text) received.
+		 * 
+		 * @return The data.
+		 */
+		public String getData() {
+			return data;
+		}
+		
+		/**
+		 * Retrieves the phone number that sent the SMS.
+		 * 
+		 * @return The phone number.
+		 */
+		public String getPhone() {
+			return phone;
+		}
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/models/NetworkMessageTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/NetworkMessageTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import static org.junit.Assert.*;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class NetworkMessageTest {
+
+	// Constants.
+	private final static String DATA = "Data";
+	
+	// Variables.
+	private static IP32BitAddress ipAddress;
+	
+	private static int sourcePort = 123;
+	private static int destPort = 456;
+	
+	private static NetworkProtocol protocol = NetworkProtocol.TCP;
+	
+	@BeforeClass
+	public static void setupOnce() {
+		ipAddress = Mockito.mock(IP32BitAddress.class);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol byte[])}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} cannot be created if the IP address is null.</p>
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testCreateNullIP() {
+		new NetworkMessage(null, sourcePort, destPort, protocol, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol, byte[])}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} cannot be created if the protocol is null.</p>
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testCreateNullProtocol() {
+		new NetworkMessage(ipAddress, sourcePort, destPort, null, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol, byte[])}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} cannot be created if the destination port is 
+	 * greater than 65535.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testCreateIllegalSourcePortBig() {
+		new NetworkMessage(ipAddress, 80000, destPort, protocol, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol, byte[])}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} cannot be created if the source port is negative.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testCreateIllegalSourcePortNegative() {
+		new NetworkMessage(ipAddress, -5, destPort, protocol, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol, byte[])}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} cannot be created if the destination port is 
+	 * greater than 65535.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testCreateIllegalDestPortBig() {
+		new NetworkMessage(ipAddress, sourcePort, 80000, protocol, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol, byte[])}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} cannot be created if the destination port is 
+	 * negative.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testCreateIllegalDestPortNegative() {
+		new NetworkMessage(ipAddress, sourcePort, -5, protocol, DATA.getBytes());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol, byte[])}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} cannot be created if the data is null.</p>
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testCreateNullData() {
+		new NetworkMessage(ipAddress, sourcePort, destPort, protocol, null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol, byte[], boolean)}, 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getIPAddress()},
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getSourcePort()}, 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getDestPort()}, 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getProtocol()},  
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getData()} and 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getDataString()}, 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#isBroadcast()}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} can be created successfully and the getters work 
+	 * properly when the message is unicast.</p>
+	 */
+	@Test
+	public void testCreateSuccessNotBroadcast() {
+		NetworkMessage networkMessage = new NetworkMessage(ipAddress, sourcePort, destPort, protocol, DATA.getBytes(), false);
+		
+		assertEquals(ipAddress, networkMessage.getIPAddress());
+		assertEquals(sourcePort, networkMessage.getSourcePort());
+		assertEquals(destPort, networkMessage.getDestPort());
+		assertEquals(protocol, networkMessage.getProtocol());
+		assertArrayEquals(DATA.getBytes(), networkMessage.getData());
+		assertEquals(DATA, networkMessage.getDataString());
+		assertFalse(networkMessage.isBroadcast());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.NetworkMessage#NetworkMessage(IP32BitAddress, int, int, NetworkProtocol, byte[], boolean)}, 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getIPAddress()},
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getSourcePort()}, 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getDestPort()}, 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getProtocol()},  
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getData()} and 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#getDataString()}, 
+	 * {@link com.digi.xbee.api.models.NetworkMessage#isBroadcast()}.
+	 * 
+	 * <p>Verify that the {@code NetworkMessage} can be created successfully and the getters work 
+	 * properly when the message is broadcast.</p>
+	 */
+	@Test
+	public void testCreateSuccessBroadcast() {
+		NetworkMessage networkMessage = new NetworkMessage(ipAddress, sourcePort, destPort, protocol, DATA.getBytes(), true);
+		
+		assertEquals(ipAddress, networkMessage.getIPAddress());
+		assertEquals(sourcePort, networkMessage.getSourcePort());
+		assertEquals(destPort, networkMessage.getDestPort());
+		assertEquals(protocol, networkMessage.getProtocol());
+		assertArrayEquals(DATA.getBytes(), networkMessage.getData());
+		assertEquals(DATA, networkMessage.getDataString());
+		assertTrue(networkMessage.isBroadcast());
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/models/SMSMessageTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/SMSMessageTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class SMSMessageTest {
+
+	// Constants.
+	private final static String DATA = "Data";
+	private final static String PHONE = "0123456789";
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.SMSMessage#SMSMessage(String, String)}.
+	 * 
+	 * <p>Verify that the {@code SMSMessage} cannot be created if the phone number is null.</p>
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testCreateNullPhone() {
+		new SMSMessage(null, DATA);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.SMSMessage#SMSMessage(String, String)}.
+	 * 
+	 * <p>Verify that the {@code SMSMessage} cannot be created if the data is null.</p>
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testCreateNullData() {
+		new SMSMessage(PHONE, null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.SMSMessage#SMSMessage(String, String)}, 
+	 * {@link com.digi.xbee.api.models.SMSMessage#getPhoneNumber()} and
+	 * {@link com.digi.xbee.api.models.SMSMessage#getData()}.
+	 * 
+	 * <p>Verify that the {@code SMSMessage} can be created successfully and the getters work 
+	 * properly.</p>
+	 */
+	@Test
+	public void testCreateSuccessNotBroadcast() {
+		SMSMessage smsMessage = new SMSMessage(PHONE, DATA);
+		
+		assertEquals(PHONE, smsMessage.getPhoneNumber());
+		assertEquals(DATA, smsMessage.getData());
+	}
+}


### PR DESCRIPTION
- Added support to send and read network data in WLAN devices.
- Added some methods to change the communication protocol and to start and
  stop listening for network data in WLAN devices.
- Added support to send SMS in Cellular devices.
- Added listeners to be notified when new network data is available in WLAN
  devices and when new SMS is available in Cellular devices.
- Added unit tests for all the new methods and classes.

Signed-off-by: Diego Escalona <diego.escalona@digi.com>