### PR TITLE
cellular: add the connect to echo server example

### DIFF
--- a/examples/communication/ip/ConnectToEchoServerSample/ReadMe.txt
+++ b/examples/communication/ip/ConnectToEchoServerSample/ReadMe.txt
@@ -1,0 +1,62 @@
+  Introduction
+  ------------
+  This sample Java application shows how to connect an Internet radio module 
+  to an echo server to send and receive data using the XBee Java Library. In 
+  this example, data is sent to an echo server that echoes it back to be read 
+  by the module. The application will block during the transmission and read 
+  requests, but you will be notified if there is any error during the process.
+  
+  NOTE: This example uses the Cellular device (CellularDevice) class, but it 
+        can be applied to other Internet capable XBee device classes such as
+        WiFiDevice.
+
+
+  Files
+  -----
+    * com.digi.xbee.api.connecttoechoserver.MainApp.java:
+      Main application class. It instantiates a Cellular device and establishes 
+      a serial connection with it. Then, sends the data to the echo server and 
+      reads it back printing out the result of the process.
+
+
+  Requirements
+  ------------
+  To run this example you will need:
+  
+    * One Internet capable XBee radio (for example a Cellular radio) in API 
+      mode and its corresponding carrier board (XBIB or equivalent).
+    * The XCTU application (available at www.digi.com/xctu).
+
+
+  Example setup
+  -------------
+    1) Plug the Internet radio into the XBee adapter and connect it to your 
+       computer's USB or serial port.
+       
+    2) Ensure that the module is in API mode and connected to the Internet.
+       For further information on how to perform this task, read the 
+       'Configuring Your XBee Modules' topic of the Getting Started guide.
+       
+    3) Set the port and baud rate of the XBee radio in the MainApp class.
+       If you configured the module in the previous step with the XCTU, you 
+       will see the port number and baud rate in the 'Port' label of the device 
+       on the left view.
+       
+    4) Optionally, modify the text to be sent to the echo server changing the 
+       value of the 'TEXT' variable.
+
+
+  Running the example
+  -------------------
+  First, build and launch the application. When the application starts, it 
+  connects to the echo server and sends the "Hello XBee!" message. To test 
+  the functionality, check that the following message (among others) is 
+  printed out in the console of the launched application:
+    
+    "Echo response received from 52.43.121.77:11001 >> '<TEXT>'"
+    
+   - Where <TEXT> is the text sent to the server and echoed back.
+    
+  That message indicates that the echo server echoed back the text sent and it 
+  was read by the Internet radio successfully.
+  

--- a/examples/communication/ip/ConnectToEchoServerSample/pom.xml
+++ b/examples/communication/ip/ConnectToEchoServerSample/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.digi.xbee</groupId>
+		<artifactId>xbjlib-parent</artifactId>
+		<version>1.1.1</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>connect-to-echo-server-sample</artifactId>
+	<packaging>jar</packaging>
+
+	<name>Connect to Echo Server Sample</name>
+
+	<properties>
+		<rxtx.native.libs.dir>rxtx-native-libs</rxtx.native.libs.dir>
+	</properties>
+
+	<build>
+		<sourceDirectory>src</sourceDirectory>
+		<directory>../../../target/examples/communication/ip/ConnectToEchoServerSample</directory>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>${exec.maven.version}</version>
+				<configuration>
+					<executable>java</executable>
+					<arguments>
+						<argument>-Djava.library.path=${project.build.directory}/../../../${rxtx.native.libs.dir}</argument>
+						<argument>-classpath</argument>
+						<!-- automatically creates the classpath using all project dependencies,
+							 also adding the project build directory -->
+						<classpath/>
+						<argument>com.digi.xbee.api.connecttoechoserver.MainApp</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.digi.xbee</groupId>
+			<artifactId>xbjlib</artifactId>
+			<version>${project.version}</version>
+			<type>jar</type>
+		</dependency>
+	</dependencies>
+</project>

--- a/examples/communication/ip/ConnectToEchoServerSample/src/com/digi/xbee/api/connecttoechoserver/MainApp.java
+++ b/examples/communication/ip/ConnectToEchoServerSample/src/com/digi/xbee/api/connecttoechoserver/MainApp.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.connecttoechoserver;
+
+import com.digi.xbee.api.CellularDevice;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.models.IP32BitAddress;
+import com.digi.xbee.api.models.NetworkMessage;
+import com.digi.xbee.api.models.NetworkProtocol;
+
+/**
+ * XBee Java Library Connect to Echo Server sample application.
+ * 
+ * <p>This example connects to an echo server, sends data to it and reads the 
+ * echoed data.</p>
+ * 
+ * <p>For a complete description on the example, refer to the 'ReadMe.txt' file
+ * included in the root directory.</p>
+ */
+public class MainApp {
+	
+	/* Constants */
+	
+	// TODO Replace with the serial port where your sender module is connected to.
+	private static final String PORT = "COM1";
+	// TODO Replace with the baud rate of your sender module.
+	private static final int BAUD_RATE = 9600;
+	// TODO Optionally, replace with the text you want to send to the server.
+	private static final String TEXT = "Hello XBee!";
+	
+	private static final IP32BitAddress ECHO_SERVER = new IP32BitAddress("52.43.121.77");
+	
+	private static final int ECHO_SERVER_PORT = 11001;
+	
+	private static final NetworkProtocol PROTOCOL_TCP = NetworkProtocol.TCP;
+	
+	/**
+	 * Application main method.
+	 * 
+	 * @param args Command line arguments.
+	 */
+	public static void main(String[] args) {
+		System.out.println(" +---------------------------------------------------+");
+		System.out.println(" |  XBee Java Library Connect to Echo Server Sample  |");
+		System.out.println(" +---------------------------------------------------+\n");
+		
+		CellularDevice myDevice = new CellularDevice(PORT, BAUD_RATE);
+		byte[] dataToSend = TEXT.getBytes();
+		
+		try {
+			myDevice.open();
+			
+			System.out.format("Sending text to %s:%s >> '%s'... ", ECHO_SERVER, ECHO_SERVER_PORT,
+					new String(dataToSend));
+			myDevice.sendNetworkData(ECHO_SERVER, ECHO_SERVER_PORT, PROTOCOL_TCP, TEXT.getBytes());
+			
+			System.out.println("Success");
+			
+			// Read the echoed data.
+			NetworkMessage response = myDevice.readNetworkData();
+			if (response == null) {
+				System.out.format("Echo response was not received from the server."); 
+				System.exit(1);
+			}
+			System.out.format("Echo response received from %s:%s >> '%s'", response.getIPAddress(), 
+					response.getSourcePort(),
+					response.getDataString());
+		} catch (XBeeException e) {
+			System.out.println("Error sendind data to the echo server");
+			e.printStackTrace();
+			System.exit(1);
+		} finally {
+			myDevice.close();
+		}
+	}
+}


### PR DESCRIPTION
- Although the example uses the CellularDevice class, it is also valid
  for the WiFiDevice one.
- The example is located in the 'communication/ip' category. More examples
  will be added here in the future.

https://jira.digi.com/browse/XBJAPI-294

Signed-off-by: Diego Escalona <diego.escalona@digi.com>