### PR TITLE
wifi: add basic support to discover and instantiate Wi-Fi radio modules

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
@@ -409,6 +409,7 @@ public abstract class AbstractXBeeDevice {
 		XBeeProtocol protocol = getXBeeProtocol();
 		if (protocol != XBeeProtocol.DIGI_MESH 
 				&& protocol != XBeeProtocol.DIGI_POINT
+				&& protocol != XBeeProtocol.XBEE_WIFI
 				&& protocol != XBeeProtocol.CELLULAR
 				&& protocol != XBeeProtocol.UNKNOWN) {
 			response = getParameter("MY");

--- a/library/src/main/java/com/digi/xbee/api/CellularDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/CellularDevice.java
@@ -41,6 +41,7 @@ import com.digi.xbee.api.utils.ByteUtils;
  * @see DigiMeshDevice
  * @see DigiPointDevice
  * @see Raw802Device
+ * @see WiFiDevice
  * @see ZigBeeDevice
  */
 public class CellularDevice extends IPDevice {

--- a/library/src/main/java/com/digi/xbee/api/DigiMeshDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/DigiMeshDevice.java
@@ -30,6 +30,7 @@ import com.digi.xbee.api.models.XBeeProtocol;
  * @see CellularDevice
  * @see DigiPointDevice
  * @see Raw802Device
+ * @see WiFiDevice
  * @see ZigBeeDevice
  */
 public class DigiMeshDevice extends XBeeDevice {

--- a/library/src/main/java/com/digi/xbee/api/DigiPointDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/DigiPointDevice.java
@@ -31,6 +31,7 @@ import com.digi.xbee.api.models.XBeeProtocol;
  * @see CellularDevice
  * @see DigiMeshDevice
  * @see Raw802Device
+ * @see WiFiDevice
  * @see ZigBeeDevice
  */
 public class DigiPointDevice extends XBeeDevice {

--- a/library/src/main/java/com/digi/xbee/api/IPDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/IPDevice.java
@@ -39,6 +39,7 @@ import com.digi.xbee.api.utils.HexUtils;
  * This class provides common functionality for XBee IP devices.
  * 
  * @see CellularDevice
+ * @see WiFiDevice
  */
 public class IPDevice extends XBeeDevice {
 

--- a/library/src/main/java/com/digi/xbee/api/Raw802Device.java
+++ b/library/src/main/java/com/digi/xbee/api/Raw802Device.java
@@ -34,6 +34,7 @@ import com.digi.xbee.api.utils.HexUtils;
  * @see CellularDevice
  * @see DigiMeshDevice
  * @see DigiPointDevice
+ * @see WiFiDevice
  * @see ZigBeeDevice
  */
 public class Raw802Device extends XBeeDevice {

--- a/library/src/main/java/com/digi/xbee/api/WiFiDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/WiFiDevice.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import com.digi.xbee.api.connection.IConnectionInterface;
+import com.digi.xbee.api.connection.serial.SerialPortParameters;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.XBeeDeviceException;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.models.WiFiAssociationIndicationStatus;
+import com.digi.xbee.api.models.XBeeProtocol;
+import com.digi.xbee.api.utils.ByteUtils;
+
+/**
+ * This class represents a local Wi-Fi device.
+ * 
+ * @see XBeeDevice
+ * @see CellularDevice
+ * @see DigiMeshDevice
+ * @see DigiPointDevice
+ * @see Raw802Device
+ * @see ZigBeeDevice
+ */
+public class WiFiDevice extends IPDevice {
+	
+	/**
+	 * Class constructor. Instantiates a new {@code WiFiDevice} object in 
+	 * the given port name and baud rate.
+	 * 
+	 * @param port Serial port name where Wi-Fi device is attached to.
+	 * @param baudRate Serial port baud rate to communicate with the device. 
+	 *                 Other connection parameters will be set as default (8 
+	 *                 data bits, 1 stop bit, no parity, no flow control).
+	 * 
+	 * @throws IllegalArgumentException if {@code baudRate < 0}.
+	 * @throws NullPointerException if {@code port == null}.
+	 * 
+	 * @see #WiFiDevice(IConnectionInterface)
+	 * @see #WiFiDevice(String, SerialPortParameters)
+	 * @see #WiFiDevice(String, int, int, int, int, int)
+	 */
+	public WiFiDevice(String port, int baudRate) {
+		this(XBee.createConnectiontionInterface(port, baudRate));
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new {@code WiFiDevice} object in 
+	 * the given serial port name and settings.
+	 * 
+	 * @param port Serial port name where Wi-Fi device is attached to.
+	 * @param baudRate Serial port baud rate to communicate with the device.
+	 * @param dataBits Serial port data bits.
+	 * @param stopBits Serial port data bits.
+	 * @param parity Serial port data bits.
+	 * @param flowControl Serial port data bits.
+	 * 
+	 * @throws IllegalArgumentException if {@code baudRate < 0} or
+	 *                                  if {@code dataBits < 0} or
+	 *                                  if {@code stopBits < 0} or
+	 *                                  if {@code parity < 0} or
+	 *                                  if {@code flowControl < 0}.
+	 * @throws NullPointerException if {@code port == null}.
+	 * 
+	 * @see #WiFiDevice(IConnectionInterface)
+	 * @see #WiFiDevice(String, int)
+	 * @see #WiFiDevice(String, SerialPortParameters)
+	 */
+	public WiFiDevice(String port, int baudRate, int dataBits, int stopBits, int parity, int flowControl) {
+		this(port, new SerialPortParameters(baudRate, dataBits, stopBits, parity, flowControl));
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new {@code WiFiDevice} object in 
+	 * the given serial port name and parameters.
+	 * 
+	 * @param port Serial port name where Wi-Fi device is attached to.
+	 * @param serialPortParameters Object containing the serial port parameters.
+	 * 
+	 * @throws NullPointerException if {@code port == null} or
+	 *                              if {@code serialPortParameters == null}.
+	 * 
+	 * @see #WiFiDevice(IConnectionInterface)
+	 * @see #WiFiDevice(String, int)
+	 * @see #WiFiDevice(String, int, int, int, int, int)
+	 * @see com.digi.xbee.api.connection.serial.SerialPortParameters
+	 */
+	public WiFiDevice(String port, SerialPortParameters serialPortParameters) {
+		this(XBee.createConnectiontionInterface(port, serialPortParameters));
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new {@code WiFiDevice} object with 
+	 * the given connection interface.
+	 * 
+	 * @param connectionInterface The connection interface with the physical 
+	 *                            Wi-Fi device.
+	 * 
+	 * @throws NullPointerException if {@code connectionInterface == null}
+	 * 
+	 * @see #WiFiDevice(String, int)
+	 * @see #WiFiDevice(String, SerialPortParameters)
+	 * @see #WiFiDevice(String, int, int, int, int, int)
+	 * @see com.digi.xbee.api.connection.IConnectionInterface
+	 */
+	public WiFiDevice(IConnectionInterface connectionInterface) {
+		super(connectionInterface);
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see com.digi.xbee.api.XBeeDevice#open()
+	 */
+	@Override
+	public void open() throws XBeeException {
+		super.open();
+		if (xbeeProtocol != XBeeProtocol.XBEE_WIFI)
+			throw new XBeeDeviceException("XBee device is not a " + getXBeeProtocol().getDescription() + " device, it is a " + xbeeProtocol.getDescription() + " device.");
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see com.digi.xbee.api.XBeeDevice#getXBeeProtocol()
+	 */
+	@Override
+	public XBeeProtocol getXBeeProtocol() {
+		return XBeeProtocol.XBEE_WIFI;
+	}
+	
+	/**
+	 * Returns the current association status of this Wi-Fi device.
+	 * 
+	 * <p>It indicates occurrences of errors during the Wi-Fi transceiver 
+	 * initialization and connection.</p>
+	 * 
+	 * @return The association indication status of the Wi-Fi device.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws TimeoutException if there is a timeout getting the association 
+	 *                          indication status.
+	 * @throws XBeeException if there is any other XBee related exception.
+	 * 
+	 * @see com.digi.xbee.api.models.Wi-FiAssociationIndicationStatus
+	 */
+	public WiFiAssociationIndicationStatus getWiFiAssociationIndicationStatus() throws TimeoutException, 
+			XBeeException {
+		byte[] associationIndicationValue = getParameter("AI");
+		return WiFiAssociationIndicationStatus.get(ByteUtils.byteArrayToInt(associationIndicationValue));
+	}
+}

--- a/library/src/main/java/com/digi/xbee/api/ZigBeeDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/ZigBeeDevice.java
@@ -38,6 +38,7 @@ import com.digi.xbee.api.utils.HexUtils;
  * @see DigiMeshDevice
  * @see DigiPointDevice
  * @see Raw802Device
+ * @see WiFiDevice
  */
 public class ZigBeeDevice extends XBeeDevice {
 

--- a/library/src/main/java/com/digi/xbee/api/models/WiFiAssociationIndicationStatus.java
+++ b/library/src/main/java/com/digi/xbee/api/models/WiFiAssociationIndicationStatus.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import java.util.HashMap;
+
+import com.digi.xbee.api.utils.HexUtils;
+
+/**
+ * Enumerates the different association indication status for the Wi-Fi 
+ * protocol.
+ */
+public enum WiFiAssociationIndicationStatus {
+
+	// Enumeration entries
+	SUCCESSFULLY_JOINED(0x00, "Successfully joined to access point."),
+	INITIALIZING(0x01, "Initialization in progress."),
+	INITIALIZED(0x02, "Initialized, but not yet scanning."),
+	DISCONNECTING(0x13, "Disconnecting from access point."),
+	SSID_NOT_CONFIGURED(0x23, "SSID not configured"),
+	INVALID_KEY(0x24, "Encryption key invalid (NULL or invalid length)."),
+	JOIN_FAILED(0x27, "SSID found, but join failed."),
+	WAITING_FOR_AUTH(0x40, "Waiting for WPA or WPA2 authentication."),
+	WAITING_FOR_IP(0x41, "Joined to a network and waiting for IP address."),
+	SETTING_UP_SOCKETS(0x42, "Joined to a network and IP configured. Setting up listening sockets."),
+	SCANNING_FOR_SSID(0xFF, "Scanning for the configured SSID.");
+	
+	// Variables
+	private final int value;
+	
+	private final String description;
+	
+	private final static HashMap<Integer, WiFiAssociationIndicationStatus> lookupTable = new HashMap<Integer, WiFiAssociationIndicationStatus>();
+	
+	static {
+		for (WiFiAssociationIndicationStatus associationIndicationStatus:values())
+			lookupTable.put(associationIndicationStatus.getValue(), associationIndicationStatus);
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new 
+	 * {@code WiFiAssociationIndicationStatus} enumeration entry with the 
+	 * given parameters.
+	 * 
+	 * @param value Wi-Fi association indication status value.
+	 * @param description Wi-Fi association indication status description.
+	 */
+	WiFiAssociationIndicationStatus(int value, String description) {
+		this.value = value;
+		this.description = description;
+	}
+	
+	/**
+	 * Returns the Wi-Fi association indication status value.
+	 * 
+	 * @return The Wi-Fi association indication status value.
+	 */
+	public int getValue() {
+		return value;
+	}
+	
+	/**
+	 * Returns the Wi-Fi association indication status description.
+	 * 
+	 * @return The Wi-Fi association indication status description.
+	 */
+	public String getDescription() {
+		return description;
+	}
+	
+	/**
+	 * Returns the {@code WiFiAssociationIndicationStatus} associated to 
+	 * the given value.
+	 * 
+	 * @param value Value of the Wi-Fi association indication status to 
+	 *              retrieve.
+	 * 
+	 * @return The Wi-Fi association indication status of the associated 
+	 *         value, {@code null} if it could not be found in the table.
+	 */
+	public static WiFiAssociationIndicationStatus get(int value) {
+		return lookupTable.get(value);
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Enum#toString()
+	 */
+	@Override
+	public String toString() {
+		return HexUtils.byteToHexString((byte)value) + ": " + description;
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/WiFiDeviceTest.java
+++ b/library/src/test/java/com/digi/xbee/api/WiFiDeviceTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.models.WiFiAssociationIndicationStatus;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({WiFiDevice.class, WiFiAssociationIndicationStatus.class})
+public class WiFiDeviceTest {
+	
+	// Constants.
+	private static final String PARAMETER_AI = "AI";
+	private static final byte[] RESPONSE_AI = new byte[]{0x00};
+	
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+	
+	private WiFiDevice wifiDevice;
+	
+	private WiFiAssociationIndicationStatus validWiFiAIStatus = WiFiAssociationIndicationStatus.SUCCESSFULLY_JOINED;
+	
+	@Before
+	public void setup() throws Exception {
+		// Spy the WiFiDevice class.
+		SerialPortRxTx mockPort = Mockito.mock(SerialPortRxTx.class);
+		wifiDevice = PowerMockito.spy(new WiFiDevice(mockPort));
+		
+		// Always return a valid Wi-Fi association indication when requested.
+		PowerMockito.mockStatic(WiFiAssociationIndicationStatus.class);
+		PowerMockito.when(WiFiAssociationIndicationStatus.get(Mockito.anyInt())).thenReturn(validWiFiAIStatus);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#getWiFiAssociationIndicationStatus()}.
+	 * 
+	 * <p>Check that the Wi-Fi association indication method returns values 
+	 * successfully.</p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testAssociationIndicationStatus() throws Exception {
+		// Return a valid response when requesting the AI parameter value.
+		Mockito.doReturn(RESPONSE_AI).when(wifiDevice).getParameter(PARAMETER_AI);
+		
+		assertEquals(validWiFiAIStatus, wifiDevice.getWiFiAssociationIndicationStatus());
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/XBeeDeviceReadInfoTest.java
+++ b/library/src/test/java/com/digi/xbee/api/XBeeDeviceReadInfoTest.java
@@ -66,6 +66,7 @@ public class XBeeDeviceReadInfoTest {
 	private ZigBeeDevice zbDevice;
 	private Raw802Device r802Device;
 	private CellularDevice cellularDevice;
+	private WiFiDevice wifiDevice;
 	
 	@Before
 	public void setup() throws Exception {
@@ -78,6 +79,7 @@ public class XBeeDeviceReadInfoTest {
 		zbDevice = PowerMockito.spy(new ZigBeeDevice(mockPort));
 		r802Device = PowerMockito.spy(new Raw802Device(mockPort));
 		cellularDevice = PowerMockito.spy(new CellularDevice(mockPort));
+		wifiDevice = PowerMockito.spy(new WiFiDevice(mockPort));
 	}
 	
 	/**
@@ -617,6 +619,50 @@ public class XBeeDeviceReadInfoTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
 	 * 
+	 * <p>Verify that device info of a ZigBee local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidWiFiClassForZBDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.ZIGBEE;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + wifiDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(wifiDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(wifiDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(wifiDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(wifiDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(wifiDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		wifiDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
 	 * <p>Verify that device info of a DigiPoint local device cannot be read if 
 	 * the class for the specified device is not the right one. It is, there is 
 	 * an AT command exception reading the parameter.</p>
@@ -788,6 +834,50 @@ public class XBeeDeviceReadInfoTest {
 		
 		// Execute the method under test.
 		cellularDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a DigiPoint local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidWiFiClassForDPDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.DIGI_POINT;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + wifiDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(wifiDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(wifiDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(wifiDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(wifiDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(wifiDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		wifiDevice.readDeviceInfo();
 	}
 	
 	/**
@@ -969,6 +1059,50 @@ public class XBeeDeviceReadInfoTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
 	 * 
+	 * <p>Verify that device info of a 802.15.4 local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidWiFiClassFor802Device() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.RAW_802_15_4;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + wifiDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(wifiDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(wifiDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(wifiDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(wifiDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(wifiDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		wifiDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
 	 * <p>Verify that device info of a DigiMesh local device cannot be read if 
 	 * the class for the specified device is not the right one. It is, there is 
 	 * an AT command exception reading the parameter.</p>
@@ -1140,6 +1274,50 @@ public class XBeeDeviceReadInfoTest {
 		
 		// Execute the method under test.
 		cellularDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a DigiMesh local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidWiFiClassForDMDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.DIGI_MESH;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + wifiDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(wifiDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(wifiDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(wifiDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(wifiDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(wifiDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		wifiDevice.readDeviceInfo();
 	}
 	
 	/**
@@ -1321,6 +1499,270 @@ public class XBeeDeviceReadInfoTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
 	 * 
+	 * <p>Verify that device info of a Cellular local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidWiFiClassForCellularDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.CELLULAR;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + wifiDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(wifiDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(wifiDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(wifiDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(wifiDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(wifiDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		wifiDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Wi-Fi local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidDigiMeshClassForWiFiDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.XBEE_WIFI;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + dmDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(dmDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(dmDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(dmDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(dmDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(dmDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		dmDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Wi-Fi local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidDigiPointClassForWiFiDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.XBEE_WIFI;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + dpDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(dpDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(dpDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(dpDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(dpDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(dpDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		dpDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Wi-Fi local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidZigBeeClassForWiFiDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.XBEE_WIFI;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + zbDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(zbDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(zbDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(zbDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(zbDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(zbDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		zbDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Wi-Fi local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalid802ClassForWiFiDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.XBEE_WIFI;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + r802Device.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(r802Device).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(r802Device).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(r802Device).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(r802Device).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(r802Device).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		r802Device.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a Wi-Fi local device cannot be read if 
+	 * the class for the specified device is not the right one. It is, there is 
+	 * an AT command exception reading the parameter.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test
+	public void testReadDeviceInfoErrorInvalidCellularClassForWiFiDevice() throws XBeeException, IOException {
+		// Setup the resources for the test.
+		XBeeProtocol realProtocol = XBeeProtocol.XBEE_WIFI;
+		
+		exception.expect(XBeeException.class);
+		exception.expectMessage(is(equalTo("Error reading device information: "
+				+ "Your module seems to be " + realProtocol 
+				+ " and NOT " + cellularDevice.getXBeeProtocol() + ". Check if you are using" 
+				+ " the appropriate device class.")));
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(cellularDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(cellularDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(cellularDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(cellularDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(cellularDevice).getParameter(PARAMETER_VR);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(realProtocol);
+		
+		// Execute the method under test.
+		cellularDevice.readDeviceInfo();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
 	 * <p>Verify that device info of a local device can be read successfully.</p>
 	 * 
 	 * @throws XBeeException
@@ -1477,6 +1919,56 @@ public class XBeeDeviceReadInfoTest {
 	 */
 	@Test
 	public void testReadDeviceInfoSuccessCellular() throws XBeeException, IOException {
+		// Return that the protocol of the device is first unknown and then DigiPoint when asked.
+		Mockito.when(xbeeDevice.getXBeeProtocol()).thenReturn(XBeeProtocol.UNKNOWN, XBeeProtocol.CELLULAR);
+		
+		// Return a valid response when requesting the SH parameter value.
+		Mockito.doReturn(RESPONSE_SH).when(xbeeDevice).getParameter(PARAMETER_SH);
+		
+		// Return a valid response when requesting the SL parameter value.
+		Mockito.doReturn(RESPONSE_SL).when(xbeeDevice).getParameter(PARAMETER_SL);
+		
+		// Return a valid response when requesting the NI parameter value.
+		Mockito.doReturn(RESPONSE_NI).when(xbeeDevice).getParameter(PARAMETER_NI);
+		
+		// Return a valid response when requesting the HV parameter value.
+		Mockito.doReturn(RESPONSE_HV).when(xbeeDevice).getParameter(PARAMETER_HV);
+		
+		// Return a valid response when requesting the VR parameter value.
+		Mockito.doReturn(RESPONSE_VR).when(xbeeDevice).getParameter(PARAMETER_VR);
+		
+		// Return a valid response when requesting the MY parameter value.
+		Mockito.doReturn(RESPONSE_MY).when(xbeeDevice).getParameter(PARAMETER_MY);
+		
+		// Return the "real" value of the module protocol.
+		PowerMockito.mockStatic(XBeeProtocol.class);
+		PowerMockito.when(XBeeProtocol.determineProtocol(Mockito.any(HardwareVersion.class), Mockito.anyString())).thenReturn(XBeeProtocol.DIGI_POINT);
+		
+		// Initialize the device.
+		xbeeDevice.readDeviceInfo();
+		
+		// Verify that all parameters but the network address were read successfully.
+		Mockito.verify(xbeeDevice, Mockito.times(2)).getXBeeProtocol();
+		Mockito.verify(xbeeDevice, Mockito.never()).getParameter(PARAMETER_MY);
+		assertEquals(XBee16BitAddress.UNKNOWN_ADDRESS, xbeeDevice.get16BitAddress());
+		assertEquals("XBEE", xbeeDevice.getNodeID());
+		assertEquals(HardwareVersion.get(0x01), xbeeDevice.getHardwareVersion());
+		assertEquals("4567", xbeeDevice.getFirmwareVersion());
+		assertEquals(XBeeProtocol.CELLULAR, xbeeDevice.getXBeeProtocol());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.XBeeDevice#readDeviceInfo()}.
+	 * 
+	 * <p>Verify that device info of a local device can be read successfully when the 
+	 * protocol of the device is Wi-Fi. In this case the16-bit address should be null, 
+	 * but the method should read valid values for the IP address.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException
+	 */
+	@Test
+	public void testReadDeviceInfoSuccessWiFi() throws XBeeException, IOException {
 		// Return that the protocol of the device is first unknown and then DigiPoint when asked.
 		Mockito.when(xbeeDevice.getXBeeProtocol()).thenReturn(XBeeProtocol.UNKNOWN, XBeeProtocol.CELLULAR);
 		

--- a/library/src/test/java/com/digi/xbee/api/models/WiFiAssociationIndicationStatusTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/WiFiAssociationIndicationStatusTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.digi.xbee.api.utils.HexUtils;
+
+public class WiFiAssociationIndicationStatusTest {
+
+	// Variables.
+	private WiFiAssociationIndicationStatus[] associationIndicationStatusValues;
+	
+	
+	@Before
+	public void setup() {
+		// Retrieve the list of enum. values.
+		associationIndicationStatusValues = WiFiAssociationIndicationStatus.values();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiAssociationIndicationStatus#getValue()}.
+	 * 
+	 * <p>Verify that the ID of each {@code WiFiAssociationIndicationStatus} 
+	 * entry is valid.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusValues() {
+		for (WiFiAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues)
+			assertTrue(associationIndicationStatus.getValue() >= 0);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiAssociationIndicationStatus#name()}.
+	 * 
+	 * <p>Verify that the name of each {@code WiFiAssociationIndicationStatus} 
+	 * entry is valid.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusNames() {
+		for (WiFiAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues) {
+			assertNotNull(associationIndicationStatus.name());
+			assertTrue(associationIndicationStatus.name().length() > 0);
+		}
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiAssociationIndicationStatus#getDescription()}.
+	 * 
+	 * <p>Verify that the description of each {@code WiFiAssociationIndicationStatus} 
+	 * entry is valid.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusDescriptions() {
+		for (WiFiAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues) {
+			assertNotNull(associationIndicationStatus.getDescription());
+			assertTrue(associationIndicationStatus.getDescription().length() > 0);
+		}
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiAssociationIndicationStatus#get(int)}.
+	 * 
+	 * <p>Verify that each {@code WiFiAssociationIndicationStatus} entry can be 
+	 * retrieved statically using its value.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusStaticAccess() {
+		for (WiFiAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues)
+			assertEquals(associationIndicationStatus, WiFiAssociationIndicationStatus.get(associationIndicationStatus.getValue()));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiAssociationIndicationStatus#get(int)}.
+	 * 
+	 * <p>Verify that when trying to get an invalid {@code WiFiAssociationIndicationStatus} 
+	 * entry, a {@code null} entry is retrieved.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusStaticInvalidAccess() {
+		assertNull(WiFiAssociationIndicationStatus.get(0xAA));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiAssociationIndicationStatus#toString()}.
+	 * 
+	 * <p>Verify that the {@code toString()} method of an {@code WiFiAssociationIndicationStatus} 
+	 * entry returns its description correctly.</p>
+	 */
+	@Test
+	public void testAssociationIndicationStatusToString() {
+		for (WiFiAssociationIndicationStatus associationIndicationStatus:associationIndicationStatusValues)
+			assertEquals(HexUtils.byteToHexString((byte)associationIndicationStatus.getValue()) + ": " + associationIndicationStatus.getDescription(), associationIndicationStatus.toString());
+	}
+}


### PR DESCRIPTION
- Added the WiFiDevice class that represents a Wi-Fi radio module.
- Added a new enumerator (WiFiAssociationIndicationStatus) to list the
  possible association indication status of a Wi-Fi device.
- Written the unit tests for the new code and updated some others.

https://jira.digi.com/browse/XBJAPI-317

Signed-off-by: Diego Escalona <diego.escalona@digi.com>