### PR TITLE
wifi: add support to discover and connect to access points

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/WiFiDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/WiFiDevice.java
@@ -11,14 +11,28 @@
  */
 package com.digi.xbee.api;
 
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.digi.xbee.api.connection.IConnectionInterface;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
 import com.digi.xbee.api.exceptions.TimeoutException;
 import com.digi.xbee.api.exceptions.XBeeDeviceException;
 import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.listeners.IPacketReceiveListener;
+import com.digi.xbee.api.models.ATCommandStatus;
+import com.digi.xbee.api.models.AccessPoint;
 import com.digi.xbee.api.models.WiFiAssociationIndicationStatus;
+import com.digi.xbee.api.models.WiFiEncryptionType;
 import com.digi.xbee.api.models.XBeeProtocol;
+import com.digi.xbee.api.packet.APIFrameType;
+import com.digi.xbee.api.packet.XBeeAPIPacket;
+import com.digi.xbee.api.packet.XBeePacket;
+import com.digi.xbee.api.packet.common.ATCommandPacket;
+import com.digi.xbee.api.packet.common.ATCommandResponsePacket;
 import com.digi.xbee.api.utils.ByteUtils;
 
 /**
@@ -32,6 +46,20 @@ import com.digi.xbee.api.utils.ByteUtils;
  * @see ZigBeeDevice
  */
 public class WiFiDevice extends IPDevice {
+	
+	// Constants.
+	private final static int DEFAULT_WIFI_RECEIVE_TIMETOUT = 15000; // 15 seconds of timeout to connect, disconnect and discover access points.
+	
+	private static final String AS_COMMAND = "AS";
+	private static final String ERROR_ALREADY_CONNECTED = "Device is already connected to an access point.";
+	
+	private static final int DISCOVER_TIMEOUT = 30000;
+	
+	// Variables.
+	private boolean discoveringAccessPoints = false;
+	private boolean discoveringAccessPointsError = false;
+	
+	protected int wifiReceiveTimeout = DEFAULT_WIFI_RECEIVE_TIMETOUT;
 	
 	/**
 	 * Class constructor. Instantiates a new {@code WiFiDevice} object in 
@@ -149,11 +177,449 @@ public class WiFiDevice extends IPDevice {
 	 *                          indication status.
 	 * @throws XBeeException if there is any other XBee related exception.
 	 * 
-	 * @see com.digi.xbee.api.models.Wi-FiAssociationIndicationStatus
+	 * @see com.digi.xbee.api.models.WiFiAssociationIndicationStatus
 	 */
 	public WiFiAssociationIndicationStatus getWiFiAssociationIndicationStatus() throws TimeoutException, 
 			XBeeException {
 		byte[] associationIndicationValue = getParameter("AI");
 		return WiFiAssociationIndicationStatus.get(ByteUtils.byteArrayToInt(associationIndicationValue));
+	}
+	
+	/**
+	 * Discovers and reports the access point that matches the supplied SSID.
+	 * 
+	 * <p>This method blocks until the access point is discovered or the 
+	 * configured Wi-Fi receive timeout expires.</p>
+	 * 
+	 * <p>The Wi-Fi receive timeout is configured using the 
+	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
+	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * 
+	 * @param ssid The SSID of the access point to discover.
+	 * 
+	 * @return The discovered access point with the given SSID, {@code null} 
+	 *         if the timeout expires and the access point was not found.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws NullPointerException if {@code ssid == null}.
+	 * @throws TimeoutException if there is a timeout getting the access point.
+	 * @throws XBeeException if there is an error sending the discovery command.
+	 * 
+	 * @see #discoverAccessPoints()
+	 * @see #getWiFiReceiveTimeout()
+	 * @see #setWiFiReceiveTimeout(int)
+	 */
+	public AccessPoint getAccessPoint(String ssid) throws XBeeException {
+		if (ssid == null)
+			throw new NullPointerException("SSID cannot be null.");
+		
+		logger.debug("{}AS for '{}' access point.", toString(), ssid);
+		
+		List<AccessPoint> accessPointsList = discoverAccessPoints();
+		
+		for (AccessPoint accessPoint:accessPointsList) {
+			if (accessPoint.getSSID().equals(ssid))
+				return accessPoint;
+		}
+		
+		return null;
+	}
+	
+	/**
+	 * Performs a discovery to search for access points in the vicinity.
+	 * 
+	 * <p>This method blocks until all the access points are discovered or the 
+	 * configured Wi-Fi receive timeout expires.</p>
+	 * 
+	 * <p>The Wi-Fi receive timeout is configured using the 
+	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
+	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * 
+	 * @return The list of access points discovered.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws TimeoutException if there is a timeout discovering the access points.
+	 * @throws XBeeException if there is any other XBee related exception.
+	 * 
+	 * @see #getAccessPoint(String)
+	 * @see #getWiFiReceiveTimeout()
+	 * @see #setWiFiReceiveTimeout(int)
+	 */
+	public List<AccessPoint> discoverAccessPoints() throws XBeeException {
+		// Check if the connection is open.
+		if (!isOpen())
+			throw new InterfaceNotOpenException();
+		
+		final ArrayList<AccessPoint> accessPointsList = new ArrayList<AccessPoint>();
+		
+		switch (getOperatingMode()) {
+		case AT:
+		case UNKNOWN:
+		default:
+			throw new InvalidOperatingModeException(operatingMode);
+		case API:
+		case API_ESCAPE:
+			// Subscribe listener to wait for active scan responses.
+			IPacketReceiveListener packetReceiveListener = new IPacketReceiveListener() {
+				/*
+				 * (non-Javadoc)
+				 * @see com.digi.xbee.api.listeners.IPacketReceiveListener#packetReceived(com.digi.xbee.api.packet.XBeePacket)
+				 */
+				@Override
+				public void packetReceived(XBeePacket receivedPacket) {
+					if (!discoveringAccessPoints)
+						return;
+					
+					try {
+						if (((XBeeAPIPacket)receivedPacket).getFrameType() != APIFrameType.AT_COMMAND_RESPONSE)
+							return;
+						ATCommandResponsePacket response = (ATCommandResponsePacket)receivedPacket;
+						if (!response.getCommand().equals(AS_COMMAND))
+							return;
+						
+						// Check for error.
+						if (response.getStatus() == ATCommandStatus.ERROR) {
+							discoveringAccessPointsError = true;
+							discoveringAccessPoints = false;
+						// Check for end of discovery.
+						} else if (response.getCommandValue() == null 
+								|| response.getCommandValue().length == 0)
+							discoveringAccessPoints = false;
+						else {
+							AccessPoint accessPoint = parseDiscoveredAccessPoint(response.getCommandValue());
+							if (accessPoint != null)
+								accessPointsList.add(accessPoint);
+						}
+					} catch (ClassCastException e) {
+						// Do nothing here.
+					}
+				}
+			};
+			
+			logger.debug("{}Start discovering access points.", toString());
+			addPacketListener(packetReceiveListener);
+			
+			try {
+				discoveringAccessPoints = true;
+				// Send the active scan command.
+				sendPacketAsync(new ATCommandPacket(getNextFrameID(), AS_COMMAND, ""));
+				
+				// Wait until the discovery process finishes or timeouts.
+				long deadLine = System.currentTimeMillis() + DISCOVER_TIMEOUT;
+				while (discoveringAccessPoints && System.currentTimeMillis() < deadLine)
+					sleep(100);
+				
+				// Check if we exited because of a timeout.
+				if (discoveringAccessPoints)
+					throw new TimeoutException();
+				// Check if there was an error in the active scan command (device is already connected).
+				if (discoveringAccessPointsError)
+					throw new XBeeException(ERROR_ALREADY_CONNECTED);
+			} finally {
+				discoveringAccessPoints = false;
+				discoveringAccessPointsError = false;
+				removePacketListener(packetReceiveListener);
+				logger.debug("{}Stop discovering access points.", toString());
+			}
+		}
+		
+		return accessPointsList;
+	}
+	
+	/**
+	 * Connects to the access point with provided SSID.
+	 * 
+	 * <p>This method blocks until the connection with the access point is 
+	 * established or the configured Wi-Fi receive timeout expires.</p>
+	 * 
+	 * <p>The Wi-Fi receive timeout is configured using the 
+	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
+	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * 
+	 * <p>Once the module is connected to the access point, you can issue 
+	 * the {@link #writeChanges()} method to save the connection settings. This 
+	 * way the module will try to connect to the access point every time it 
+	 * is powered on.</p>
+	 * 
+	 * @param ssid The SSID of the access point to connect to.
+	 * @param password The password for the access point, {@code null} if it 
+	 *                 does not have any encryption enabled.
+	 * 
+	 * @return {@code true} if the module connected to the access point 
+	 *         successfully, {@code false} otherwise.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws NullPointerException if {@code ssid == null}.
+	 * @throws TimeoutException if there is a timeout sending the connect 
+	 *                          commands.
+	 * @throws XBeeException if the SSID provided is {@code null} or if there 
+	 *                       is any other XBee related exception.
+	 * 
+	 * @see #connect(AccessPoint, String)
+	 * @see #disconnect()
+	 * @see #discoverAccessPoints()
+	 * @see #getAccessPoint(String)
+	 * @see #getWiFiReceiveTimeout()
+	 * @see #setWiFiReceiveTimeout(int)
+	 */
+	public boolean connect(String ssid, String password) 
+			throws TimeoutException, XBeeException {
+		if (ssid == null)
+			throw new NullPointerException("SSID cannot be null.");
+		
+		AccessPoint accessPoint = getAccessPoint(ssid);
+		if (accessPoint == null)
+			throw new XBeeException("Couldn't find any access point with the proviced SSID.");
+		
+		return connect(accessPoint, password);
+	}
+	
+	/**
+	 * Connects to the provided access point.
+	 * 
+	 * <p>This method blocks until the connection with the access point is 
+	 * established or the configured Wi-Fi receive timeout expires.</p>
+	 * 
+	 * <p>The Wi-Fi receive timeout is configured using the 
+	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
+	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * 
+	 * <p>Once the module is connected to the access point, you can issue 
+	 * the {@code writeSettings} method to save the connection settings. This 
+	 * way the module will try to connect to the access point every time it 
+	 * is powered on.</p>
+	 * 
+	 * @param accessPoint The access point to connect to.
+	 * @param password The password for the access point, {@code null} if it 
+	 *                 does not have any encryption enabled.
+	 * 
+	 * @return {@code true} if the module connected to the access point 
+	 *         successfully, {@code false} otherwise.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws NullPointerException if {@code accessPoint == null}.
+	 * @throws TimeoutException if there is a timeout sending the connect 
+	 *                          commands.
+	 * @throws XBeeException if there is any other XBee related exception.
+	 * 
+	 * @see #connect(String, String)
+	 * @see #disconnect()
+	 * @see #discoverAccessPoints()
+	 * @see #getAccessPoint(String)
+	 * @see #getWiFiReceiveTimeout()
+	 * @see #setWiFiReceiveTimeout(int)
+	 * @see com.digi.xbee.api.models.AccessPoint
+	 */
+	public boolean connect(AccessPoint accessPoint, String password) 
+			throws TimeoutException, XBeeException {
+		if (accessPoint == null)
+			throw new NullPointerException("Access point cannot be null.");
+		
+		// Set connection parameters.
+		setParameter("ID", accessPoint.getSSID().getBytes());
+		setParameter("EE", new byte[]{(byte)accessPoint.getEncryptionType().getID()});
+		if (password != null && accessPoint.getEncryptionType() != WiFiEncryptionType.NONE)
+			setParameter("PK", password.getBytes());
+		
+		// Wait for the module to connect to the access point.
+		long deadLine = System.currentTimeMillis() + wifiReceiveTimeout;
+		while (System.currentTimeMillis() < deadLine) {
+			sleep(100);
+			// Get the association indication value of the module.
+			byte[] status = getParameter("AI");
+			if (status == null || status.length < 1)
+				continue;
+			if (status[0] == 0)
+				return true;
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * Disconnects from the access point the device is connected to.
+	 * 
+	 * <p>This method blocks until the device disconnects totally from the 
+	 * access point or the configured Wi-Fi receive timeout expires.</p>
+	 * 
+	 * <p>The Wi-Fi receive timeout is configured using the 
+	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
+	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * 
+	 * @return {@code true} if the module disconnected from the access point 
+	 *         successfully, {@code false} otherwise.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws TimeoutException if there is a timeout sending the disconnect 
+	 *                          command.
+	 * @throws XBeeException if there is any other XBee related exception.
+	 * 
+	 * @see #connect(AccessPoint, String, int)
+	 * @see #connect(String, String, int)
+	 * @see #getWiFiReceiveTimeout()
+	 * @see #setWiFiReceiveTimeout(int)
+	 */
+	public boolean disconnect() throws TimeoutException, XBeeException {
+		executeParameter("NR");
+		// Wait for the module to connect to the access point.
+		long deadLine = System.currentTimeMillis() + wifiReceiveTimeout;
+		while (System.currentTimeMillis() < deadLine) {
+			sleep(100);
+			// Get the association indication value of the module.
+			byte[] status = getParameter("AI");
+			if (status == null || status.length < 1)
+				continue;
+			// Status 0x23 (35) means the SSID is not configured.
+			if (status[0] == 0x23)
+				return true;
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * Returns whether the device is connected to an access point or not.
+	 * 
+	 * @return {@code true} if the device is connected to an access point, 
+	 *         {@code false} otherwise.
+	 * 
+	 * @throws InterfaceNotOpenException if this device connection is not open.
+	 * @throws TimeoutException if there is a timeout getting the association 
+	 *                          indication status.
+	 * @throws XBeeException if there is any other XBee related exception.
+	 * 
+	 * @see #getWiFiAssociationIndicationStatus()
+	 * @see com.digi.xbee.api.models.WiFiAssociationIndicationStatus
+	 */
+	public boolean isConnected() throws TimeoutException, XBeeException {
+		WiFiAssociationIndicationStatus status = getWiFiAssociationIndicationStatus();
+		
+		return status == WiFiAssociationIndicationStatus.SUCCESSFULLY_JOINED;
+	}
+	
+	/**
+	 * Parses the given active scan API data and returns an {@code AccessPoint} 
+	 * object.
+	 * 
+	 * @param data Data to parse.
+	 * 
+	 * @return Discovered access point. {@code null} if the parsed data does
+	 *         not correspond to an access point.
+	 */
+	private AccessPoint parseDiscoveredAccessPoint(byte[] data) {
+		AccessPoint accessPoint = null;
+		
+		int version;
+		int channel;
+		int security;
+		int signalStrength;
+		int signalQuality;
+		
+		String ssidName = "";
+		
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+		if (inputStream.available() == 0)
+			return null;
+		// Read the version.
+		version = ByteUtils.byteArrayToInt((ByteUtils.readBytes(1, inputStream)));
+		if (inputStream.available() == 0)
+			return null;
+		// Read the channel.
+		channel = ByteUtils.byteArrayToInt((ByteUtils.readBytes(1, inputStream)));
+		if (inputStream.available() == 0)
+			return null;
+		// Read the encryption type.
+		security = ByteUtils.byteArrayToInt((ByteUtils.readBytes(1, inputStream)));
+		if (inputStream.available() == 0)
+			return null;
+		// Read the signal strength and generate the signal quality.
+		signalStrength = ByteUtils.byteArrayToInt((ByteUtils.readBytes(1, inputStream)));
+		signalQuality = getSignalQuality(version, signalStrength);
+		
+		// Read the SSID name.
+		if (inputStream.available() == 0)
+			return null;
+		int readByte = -1;
+		while ((readByte = inputStream.read()) != -1)
+			ssidName += new String(new byte[]{(byte)(readByte & 0xFF)});
+		
+		// Build the access point object.
+		accessPoint = new AccessPoint(ssidName, WiFiEncryptionType.get(security), channel, signalQuality);
+		
+		logger.debug("{}Discovered: SSID[{}], encryption[{}], channel[{}], signal quality[{}].",
+				toString(), ssidName, WiFiEncryptionType.get(security).name(), channel, signalQuality);
+		
+		return accessPoint;
+	}
+	
+	/**
+	 * Converts the signal strength value in signal quality (%) based on the 
+	 * provided Wi-Fi version.
+	 * 
+	 * @param wifiVersion Wi-Fi protocol version of the Wi-Fi XBee device.
+	 * @param signalStrength Signal strength value to convert to %.
+	 * 
+	 * @return The signal quality in %.
+	 */
+	private int getSignalQuality(int wifiVersion, int signalStrength) {
+		int quality;
+		
+		if (wifiVersion == 1) {
+			if (signalStrength <= -100)
+				quality = 0;
+			else if(signalStrength >= -50)
+				quality = 100;
+			else
+				quality = (2 * (signalStrength + 100)); 
+		} else
+			quality = 2 * signalStrength;
+		
+		if (quality > 100)
+			quality = 100;
+		if (quality < 0)
+			quality = 0;
+		
+		return quality;
+	}
+	
+	/**
+	 * Sleeps the thread for the given number of milliseconds.
+	 * 
+	 * @param milliseconds The number of milliseconds that the thread should 
+	 *        be sleeping.
+	 */
+	private void sleep(int milliseconds) {
+		try {
+			Thread.sleep(milliseconds);
+		} catch (InterruptedException e) { }
+	}
+	
+	/**
+	 * Returns the Wi-Fi configured timeout for connecting, disconnecting and 
+	 * discovering access points.
+	 * 
+	 * @return The current Wi-Fi receive timeout in milliseconds.
+	 * 
+	 * @see #setWiFiReceiveTimeout(int)
+	 */
+	public int getWiFiReceiveTimeout() {
+		return wifiReceiveTimeout;
+	}
+	
+	/**
+	 * Configures the Wi-Fi timeout in milliseconds connecting, disconnecting 
+	 * and discovering access points.
+	 *  
+	 * @param wifiReceiveTimeout The new Wi-Fi receive timeout in milliseconds.
+	 * 
+	 * @throws IllegalArgumentException if {@code wifiReceiveTimeout < 0}.
+	 * 
+	 * @see #getWiFiReceiveTimeout()
+	 */
+	public void setWiFiReceiveTimeout(int wifiReceiveTimeout) {
+		if (wifiReceiveTimeout < 0)
+			throw new IllegalArgumentException("Wi-Fi receive timeout cannot be less than 0.");
+		
+		this.wifiReceiveTimeout = wifiReceiveTimeout;
 	}
 }

--- a/library/src/main/java/com/digi/xbee/api/models/AccessPoint.java
+++ b/library/src/main/java/com/digi/xbee/api/models/AccessPoint.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+/**
+ * This class represents an Access Point for the Wi-Fi protocol. It contains 
+ * SSID, the encryption type and the link quality between the Wi-Fi module and 
+ * the access point.
+ * 
+ * <p>This class is used within the XBee Java Library to list the access points 
+ * and connect to a specific one in the Wi-Fi protocol.</p>
+ */
+public class AccessPoint {
+
+	// Constants.
+	private static final String ERROR_CHANNEL = "Channel cannot be negative.";
+	private static final String ERROR_SIGNAL_QUALITY = "Signal quality must be between 0 and 100.";
+	
+	// Variables.
+	private final String ssid;
+	
+	private final WiFiEncryptionType encryptionType;
+	
+	private int channel;
+	private int signalQuality;
+	
+	/**
+	 * Class constructor. Instantiates a new object of type 
+	 * {@code AccessPoint} with the given parameters.
+	 * 
+	 * @param ssid The SSID of the access point.
+	 * @param encryptionType The encryption type configured in the access 
+	 *                       point.
+	 * 
+	 * @throws IllegalArgumentException if {@code ssid.length < 0}.
+	 * @throws NullPointerException if {@code ssid == null} or 
+	 *                              if {@code encryptionType == null}.
+	 * 
+	 * @see #AccessPoint(String, WiFiEncryptionType, int, int)
+	 * @see com.digi.xbee.api.models.WiFiEncryptionType
+	 */
+	public AccessPoint(String ssid, WiFiEncryptionType encryptionType) {
+		this(ssid, encryptionType, 0, 0);
+	}
+	
+	/**
+	 * Class constructor. Instantiates a new object of type 
+	 * {@code AccessPoint} with the given parameters.
+	 * 
+	 * @param ssid The SSID of the access point.
+	 * @param encryptionType The encryption type configured in the access 
+	 *                       point.
+	 * @param channgel Operating channel of the access point.
+	 * @param quality Signal quality with the access point in %.
+	 * 
+	 * @throws IllegalArgumentException if {@code ssid.length < 0} or 
+	 *                                  if {@code channel < 0} or 
+	 *                                  if (@code signalQuality < 0} or 
+	 *                                  if {@code signalQuality > 100}.
+	 * @throws NullPointerException if {@code ssid == null} or
+	 *                              if {@code encryptionType == null}.
+	 * 
+	 * @see #AccessPoint(String, WiFiEncryptionType)
+	 * @see com.digi.xbee.api.models.WiFiEncryptionType
+	 */
+	public AccessPoint(String ssid, WiFiEncryptionType encryptionType, int channel,
+			int signalQuality) {
+		if (ssid == null)
+			throw new NullPointerException("SSID cannot be null.");
+		if (encryptionType == null)
+			throw new NullPointerException("Encryption type cannot be null.");
+		
+		if (ssid.length() == 0)
+			throw new IllegalArgumentException("SSID cannot be empty.");
+		if (channel < 0)
+			throw new IllegalArgumentException(ERROR_CHANNEL);
+		if (signalQuality < 0 || signalQuality > 100)
+			throw new IllegalArgumentException(ERROR_SIGNAL_QUALITY);
+		
+		this.ssid = ssid;
+		this.encryptionType = encryptionType;
+		this.channel = channel;
+		this.signalQuality = signalQuality;
+	}
+	
+	/**
+	 * Returns the SSID of the access point.
+	 * 
+	 * @return The SSID of the access point.
+	 */
+	public String getSSID() {
+		return ssid;
+	}
+	
+	/**
+	 * Returns the encryption type of the access point.
+	 * 
+	 * @return The encryption type of the access point.
+	 * 
+	 * @see com.digi.xbee.api.models.WiFiEncryptionType
+	 */
+	public WiFiEncryptionType getEncryptionType() {
+		return encryptionType;
+	}
+	
+	/**
+	 * Returns the operating channel of the access point.
+	 * 
+	 * @return The operating channel of the access point.
+	 * 
+	 * @see #setChannel(int)
+	 */
+	public int getChannel() {
+		return channel;
+	}
+	
+	/**
+	 * Sets the new channel of the access point.
+	 * 
+	 * @param channel The new channel of the access point.
+	 * 
+	 * @see #getChannel()
+	 */
+	public void setChannel(int channel) {
+		if (channel < 0)
+			throw new IllegalArgumentException(ERROR_CHANNEL);
+		
+		this.channel = channel;
+	}
+	
+	/**
+	 * Returns the signal quality with the access point in %.
+	 * 
+	 * @return The signal quality with the access point in %.
+	 * 
+	 * @see #setSignalQuality(int)
+	 */
+	public int getSignalQuality() {
+		return signalQuality;
+	}
+	
+	/**
+	 * Sets the new signal quality with the access point.
+	 * 
+	 * @param signalQuality The new signal quality with the access point.
+	 * 
+	 * @see #getSignalQuality()
+	 */
+	public void setSignalQuality(int signalQuality) {
+		if (signalQuality < 0 || signalQuality > 100)
+			throw new IllegalArgumentException(ERROR_SIGNAL_QUALITY);
+		
+		this.signalQuality = signalQuality;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder message = new StringBuilder();
+		message.append(ssid);
+		message.append(" (");
+		message.append(encryptionType.name());
+		message.append(") - CH: ");
+		message.append(channel);
+		message.append(" - Signal: ");
+		message.append(signalQuality);
+		message.append("%");
+		
+		return message.toString();
+	}
+}

--- a/library/src/main/java/com/digi/xbee/api/models/WiFiEncryptionType.java
+++ b/library/src/main/java/com/digi/xbee/api/models/WiFiEncryptionType.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import java.util.HashMap;
+
+/**
+ * Enumerates the different Wi-Fi encryption types.
+ */
+public enum WiFiEncryptionType {
+
+	// Enumeration types.
+	NONE(0, "No security"),
+	WPA(1, "WPA (TKIP) security"),
+	WPA2(2, "WPA2 (AES) security"),
+	WEP(3, "WEP security");
+
+	// Variables.
+	private int id;
+
+	private String name;
+
+	private static HashMap<Integer, WiFiEncryptionType> lookupTable = new HashMap<Integer, WiFiEncryptionType>();
+
+	static {
+		for (WiFiEncryptionType encryptionType:values())
+			lookupTable.put(encryptionType.getID(), encryptionType);
+	}
+
+	/**
+	 * Class constructor. Instantiates a new {@code WiFiEncryptionType} enumeration
+	 * entry with the given parameters.
+	 *
+	 * @param id Encryption type ID.
+	 * @param name Encryption type name.
+	 */
+	private WiFiEncryptionType(int id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	/**
+	 * Retrieves the encryption type ID.
+	 *
+	 * @return Encryption type ID.
+	 */
+	public int getID() {
+		return id;
+	}
+
+	/**
+	 * Retrieves the encryption type name.
+	 *
+	 * @return Encryption type name.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Retrieves the encryption type for the given ID.
+	 *
+	 * @param id ID to retrieve the encryption type.
+	 *
+	 * @return The encryption type associated with the given ID.
+	 */
+	public static WiFiEncryptionType get(int id) {
+		return lookupTable.get(id);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Enum#toString()
+	 */
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/AccessPointsDiscoverTest.java
+++ b/library/src/test/java/com/digi/xbee/api/AccessPointsDiscoverTest.java
@@ -1,0 +1,679 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.core.IsNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.digi.xbee.api.connection.IConnectionInterface;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.listeners.IPacketReceiveListener;
+import com.digi.xbee.api.models.ATCommandStatus;
+import com.digi.xbee.api.models.AccessPoint;
+import com.digi.xbee.api.models.OperatingMode;
+import com.digi.xbee.api.models.WiFiEncryptionType;
+import com.digi.xbee.api.models.XBee16BitAddress;
+import com.digi.xbee.api.models.XBee64BitAddress;
+import com.digi.xbee.api.packet.XBeeAPIPacket;
+import com.digi.xbee.api.packet.common.ATCommandPacket;
+import com.digi.xbee.api.packet.common.ATCommandResponsePacket;
+import com.digi.xbee.api.packet.common.ReceivePacket;
+
+@PrepareForTest({WiFiDevice.class, XBee64BitAddress.class, XBee16BitAddress.class})
+@RunWith(PowerMockRunner.class)
+public class AccessPointsDiscoverTest {
+	
+	// Constants.
+	private static final String METHOD_DISCOVER_ACCESS_POINTS = "discoverAccessPoints";
+	private static final String METHOD_PARSE_DISCOVERED_ACCESS_POINT = "parseDiscoveredAccessPoint";
+	private static final String METHOD_GET_SIGNAL_QUALITY = "getSignalQuality";
+	private static final String METHOD_PARSE_DISCOVERED_AP = "parseDiscoveredAccessPoint";
+	private static final String METHOD_SLEEP = "sleep";
+		
+	// Variables.
+	private WiFiDevice wifiDevice;
+	
+	private IConnectionInterface mockedInterface;
+	
+	private IPacketReceiveListener packetListener;
+	
+	private List<XBeeAPIPacket> asAnswers = new ArrayList<XBeeAPIPacket>();
+	
+	private long currentMillis = 0;
+	
+	@Before
+	public void setUp() throws Exception {
+		asAnswers.clear();
+		packetListener = null;
+		
+		mockedInterface = PowerMockito.mock(IConnectionInterface.class);
+		wifiDevice = PowerMockito.spy(new WiFiDevice(mockedInterface));
+		
+		PowerMockito.when(wifiDevice.isOpen()).thenReturn(true);
+		PowerMockito.when(wifiDevice.getOperatingMode()).thenReturn(OperatingMode.API);
+		PowerMockito.when(wifiDevice.getNextFrameID()).thenReturn(1);
+		PowerMockito.when(wifiDevice.getConnectionInterface()).thenReturn(mockedInterface);
+		PowerMockito.when(mockedInterface.toString()).thenReturn("Mocked IConnectionInterface for NodeDiscovery test.");
+		
+		PowerMockito.doAnswer(new Answer<Object>() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				packetListener = ((IPacketReceiveListener) invocation.getArguments()[0]);
+				return null;
+			}
+		}).when(wifiDevice).addPacketListener(Mockito.any(IPacketReceiveListener.class));
+		
+		PowerMockito.doAnswer(new Answer<Object>() {
+			@Override
+			public Object answer(final InvocationOnMock invocation) throws Throwable {
+				if (packetListener == null)
+					return null;
+				Thread t = new Thread() {
+					@Override
+					public void run() {
+						if (invocation == null || invocation.getArguments() == null
+								|| invocation.getArguments().length == 0)
+							return;
+						
+						for (int i = 0; i < asAnswers.size(); i++)
+							packetListener.packetReceived(asAnswers.get(i));
+					}
+				};
+				t.start();
+				
+				return null;
+			}
+		}).when(wifiDevice).sendPacketAsync(Mockito.any(ATCommandPacket.class));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * 
+	 * <p>An {@code InterfaceNotOpenException} exception must be thrown when 
+	 * the local device connection is not open.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public final void testDiscoverAccessPointsDeviceNotOpen() throws XBeeException {
+		// Setup the resources for the test.
+		PowerMockito.when(wifiDevice.isOpen()).thenReturn(false);
+		
+		// Call the method under test.
+		wifiDevice.discoverAccessPoints();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * 
+	 * <p>An {@code InvalidOperatingModeException} exception must be thrown when 
+	 * the local device operating mode is different than API or API Escaped.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public final void testDiscoverAccessPointsInvalidOperatingMode() throws XBeeException {
+		// Setup the resources for the test.
+		PowerMockito.when(wifiDevice.getOperatingMode()).thenReturn(OperatingMode.AT);
+		
+		// Call the method under test.
+		wifiDevice.discoverAccessPoints();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#getAccessPoint(String)}.
+	 * 
+	 * <p>Verify that when asked for an access point with a {@code null} SSID, 
+	 * the method throws a {@code NullPointerException}.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test(expected=NullPointerException.class)
+	public final void testGetAccessPointNotNull() throws Exception {
+		// Call the method under test.
+		wifiDevice.getAccessPoint(null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#getAccessPoint(String)}.
+	 * 
+	 * <p>Verify that when asked for a specific access point and it is not in the list of 
+	 * discovered access points, the returned access point is null.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testGetAccessPointNotExists() throws Exception {
+		// Setup the resources for the test.
+		ArrayList<AccessPoint> accessPointsList = new ArrayList<AccessPoint>();
+		
+		// Mock a dummy access point.
+		AccessPoint mockedAccessPoint = PowerMockito.mock(AccessPoint.class);
+		PowerMockito.when(mockedAccessPoint.getSSID()).thenReturn("Dummy SSID");
+		accessPointsList.add(mockedAccessPoint);
+		
+		PowerMockito.doReturn(accessPointsList).when(wifiDevice, METHOD_DISCOVER_ACCESS_POINTS);
+		
+		// Call the method under test.
+		AccessPoint readAccessPoint = wifiDevice.getAccessPoint("Test SSID");
+		
+		// Verify the result.
+		assertThat("The discovered access point should be null", readAccessPoint, is(equalTo(null)));
+		
+		Mockito.verify(wifiDevice, Mockito.times(1)).discoverAccessPoints();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#getAccessPoint(String)}.
+	 * 
+	 * <p>Verify that when asked for a specific access point and it is not in the list of 
+	 * discovered access points, the returned access point is null.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testGetAccessPointExists() throws Exception {
+		// Setup the resources for the test.
+		String testSSID = "Test SSID";
+		ArrayList<AccessPoint> accessPointsList = new ArrayList<AccessPoint>();
+		
+		// Mock a dummy access point.
+		AccessPoint mockedAccessPoint = PowerMockito.mock(AccessPoint.class);
+		PowerMockito.when(mockedAccessPoint.getSSID()).thenReturn("Dummy SSID");
+		accessPointsList.add(mockedAccessPoint);
+		
+		// Mock the access point to get when asked.
+		AccessPoint mockedAccessPoint2 = PowerMockito.mock(AccessPoint.class);
+		PowerMockito.when(mockedAccessPoint2.getSSID()).thenReturn(testSSID);
+		accessPointsList.add(mockedAccessPoint2);
+		
+		PowerMockito.doReturn(accessPointsList).when(wifiDevice, METHOD_DISCOVER_ACCESS_POINTS);
+		
+		// Call the method under test.
+		AccessPoint readAccessPoint = wifiDevice.getAccessPoint(testSSID);
+		
+		// Verify the result.
+		assertThat("The discovered access point shouldn't be null", readAccessPoint, is(IsNull.notNullValue()));
+		assertThat("The discovered access point's SSID should match the provided one", readAccessPoint.getSSID(), is(equalTo(testSSID)));
+		
+		Mockito.verify(wifiDevice, Mockito.times(1)).discoverAccessPoints();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * 
+	 * <p>Verify that {@code discoverAccessPoints()} method throws an {@code XBeeException} 
+	 * if the device is already connected (AS response status is ERROR).</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test(expected=XBeeException.class)
+	public final void testDiscoverAccessPointsErrorConnected() throws Exception {
+		// Setup the resources for the test.
+		asAnswers.clear();
+		asAnswers.add(new ATCommandResponsePacket(1, ATCommandStatus.ERROR, "AS", null));
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		wifiDevice.discoverAccessPoints();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * 
+	 * <p>Verify that {@code discoverAccessPoints()} method throws a {@code TimeoutException} 
+	 * if it does not receive the end of discovery command after the configured timeout expires.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test(expected=TimeoutException.class)
+	public final void testDiscoverAccessPointsErrorTimeout() throws Exception {
+		// Setup the resources for the test.
+		asAnswers.clear();
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		wifiDevice.discoverAccessPoints();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * 
+	 * <p>Verify that {@code discoverAccessPoints()} method returns an empty list of 
+	 * access points if only the end answer to AS command is received.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testDiscoverAccessPointsSuccessEmpty() throws Exception {
+		// Setup the resources for the test.
+		asAnswers.clear();
+		
+		// Add the end of AS command response.
+		asAnswers.add(new ATCommandResponsePacket(1, ATCommandStatus.OK, "AS", null));
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		List<AccessPoint> accessPointsList = wifiDevice.discoverAccessPoints();
+		
+		// Verify the result.
+		assertThat("List of access points should be empty", accessPointsList.size(), is(equalTo(0)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * 
+	 * <p>Verify that {@code discoverAccessPoints()} method returns an empty list of 
+	 * access points if only the end answer to AS command is received. In this case the 
+	 * end answer has an empty (not null) parameter value.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testDiscoverAccessPointsSuccessEmptyValueEmpty() throws Exception {
+		// Setup the resources for the test.
+		asAnswers.clear();
+		
+		// Add the end of AS command response (this time the parameter is an empty byte array).
+		asAnswers.add(new ATCommandResponsePacket(1, ATCommandStatus.OK, "AS", new byte[0]));
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		List<AccessPoint> accessPointsList = wifiDevice.discoverAccessPoints();
+		
+		// Verify the result.
+		assertThat("List of access points should be empty", accessPointsList.size(), is(equalTo(0)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * 
+	 * <p>Verify that {@code discoverAccessPoints()} method returns a list with
+	 * discovered access points.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testDiscoverAccessPointsSuccess() throws Exception {
+		// Setup the resources for the test.
+		asAnswers.clear();
+		
+		// Create 2 valid access points (to be verified later with the list of discovered ones)
+		AccessPoint accessPoint1 = new AccessPoint("AP - 1", WiFiEncryptionType.NONE, 1, 60);
+		AccessPoint accessPoint2 = new AccessPoint("AP - 2", WiFiEncryptionType.WEP, 2, 40);
+		
+		// Prepare the objects to return when the 
+		PowerMockito.doReturn(accessPoint1, null, accessPoint2).when(wifiDevice, METHOD_PARSE_DISCOVERED_AP, Mockito.any(byte[].class));
+		
+		// Add some invalid AS response packets (they should be skipped) to the list of AS answers.
+		asAnswers.add(new ReceivePacket(PowerMockito.mock(XBee64BitAddress.class), PowerMockito.mock(XBee16BitAddress.class), 0, null));
+		asAnswers.add(new ATCommandResponsePacket(1, ATCommandStatus.OK, "NI", null));
+		
+		// Add a some valid AS answers to the list of AS answers.
+		asAnswers.add(createASCmdPacket(1, ATCommandStatus.OK, 2, 1, WiFiEncryptionType.NONE, 30, "AP - 1"));
+		asAnswers.add(createASCmdPacket(1, ATCommandStatus.OK, 2, 10, WiFiEncryptionType.NONE, 50, "AP - DUMMY"));
+		asAnswers.add(createASCmdPacket(1, ATCommandStatus.OK, 2, 2, WiFiEncryptionType.WEP, 20, "AP - 2"));
+		
+		// Add the end of AS command response to the list of AS answers.
+		asAnswers.add(new ATCommandResponsePacket(1, ATCommandStatus.OK, "AS", null));
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		List<AccessPoint> accessPointsList = wifiDevice.discoverAccessPoints();
+		
+		// Verify the result.
+		assertThat("List of access points should contain 2 access points", accessPointsList.size(), is(equalTo(2)));
+		assertThat("First access point from the list should equal 'accessPpoint1'", accessPointsList.get(0), is(equalTo(accessPoint1)));
+		assertThat("Second access point from the list should equal 'accessPpoint2'", accessPointsList.get(1), is(equalTo(accessPoint2)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#parseDiscoveredAccessPoint(byte[])}.
+	 * 
+	 * <p>Verify that when the access point data to be parsed does not contain a Wi-Fi version, the 
+	 * generated access point is {@code null}.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testParseDiscoveredAccessPointNoVersion() throws Exception {
+		// Setup the resources for the test.
+		byte[] data = new byte[0];
+		
+		// Call the method under test.
+		AccessPoint parsedAccessPoint = Whitebox.invokeMethod(wifiDevice, METHOD_PARSE_DISCOVERED_ACCESS_POINT, data);
+		
+		// Verify the result.
+		assertThat("Parsed access point should be null", parsedAccessPoint, is(equalTo(null)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#parseDiscoveredAccessPoint(byte[])}.
+	 * 
+	 * <p>Verify that when the access point data to be parsed does not contain channel, the 
+	 * generated access point is {@code null}.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testParseDiscoveredAccessPointNoChannel() throws Exception {
+		// Setup the resources for the test.
+		byte[] data = new byte[1];
+		data[0] = 2;                   /* version */
+		
+		// Call the method under test.
+		AccessPoint parsedAccessPoint = Whitebox.invokeMethod(wifiDevice, METHOD_PARSE_DISCOVERED_ACCESS_POINT, data);
+		
+		// Verify the result.
+		assertThat("Parsed access point should be null", parsedAccessPoint, is(equalTo(null)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#parseDiscoveredAccessPoint(byte[])}.
+	 * 
+	 * <p>Verify that when the access point data to be parsed does not contain encryption type, the 
+	 * generated access point is {@code null}.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testParseDiscoveredAccessPointNoEncType() throws Exception {
+		// Setup the resources for the test.
+		byte[] data = new byte[2];
+		data[0] = 2;                   /* version */
+		data[1] = 12;                  /* channel */
+		
+		// Call the method under test.
+		AccessPoint parsedAccessPoint = Whitebox.invokeMethod(wifiDevice, METHOD_PARSE_DISCOVERED_ACCESS_POINT, data);
+		
+		// Verify the result.
+		assertThat("Parsed access point should be null", parsedAccessPoint, is(equalTo(null)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#parseDiscoveredAccessPoint(byte[])}.
+	 * 
+	 * <p>Verify that when the access point data to be parsed does not contain signal strength, the 
+	 * generated access point is {@code null}.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testParseDiscoveredAccessPointNoSignal() throws Exception {
+		// Setup the resources for the test.
+		byte[] data = new byte[3];
+		data[0] = 2;                   /* version */
+		data[1] = 12;                  /* channel */
+		data[2] = 0;                   /* encryption type */
+		
+		// Call the method under test.
+		AccessPoint parsedAccessPoint = Whitebox.invokeMethod(wifiDevice, METHOD_PARSE_DISCOVERED_ACCESS_POINT, data);
+		
+		// Verify the result.
+		assertThat("Parsed access point should be null", parsedAccessPoint, is(equalTo(null)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#parseDiscoveredAccessPoint(byte[])}.
+	 * 
+	 * <p>Verify that when the access point data to be parsed does not contain SSID, the 
+	 * generated access point is {@code null}.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testParseDiscoveredAccessPointNoSSID() throws Exception {
+		// Setup the resources for the test.
+		byte[] data = new byte[4];
+		data[0] = 2;                   /* version */
+		data[1] = 12;                  /* channel */
+		data[2] = 0;                   /* encryption type */
+		data[3] = (byte)(42 & 0xFF);  /* signal strength */
+		PowerMockito.doReturn(50).when(wifiDevice, METHOD_GET_SIGNAL_QUALITY, Mockito.anyInt(), Mockito.anyInt());
+		
+		// Call the method under test.
+		AccessPoint parsedAccessPoint = Whitebox.invokeMethod(wifiDevice, METHOD_PARSE_DISCOVERED_ACCESS_POINT, data);
+		
+		// Verify the result.
+		assertThat("Parsed access point should be null", parsedAccessPoint, is(equalTo(null)));
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(1)).invoke(METHOD_GET_SIGNAL_QUALITY, 2, 42 & 0xFF);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#parseDiscoveredAccessPoint(byte[])}.
+	 * 
+	 * <p>Verify that when the access point data to be parsed is valid, the access 
+	 * point is generated successfully.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testParseDiscoveredAccessPointSuccess() throws Exception {
+		// Setup the resources for the test.
+		byte[] ssid = "AP SSID".getBytes();
+		AccessPoint mockedAccessPoint = PowerMockito.mock(AccessPoint.class);
+		PowerMockito.whenNew(AccessPoint.class).withAnyArguments().thenReturn(mockedAccessPoint);
+		
+		byte[] data = new byte[4 + ssid.length];
+		data[0] = 2;                   /* version */
+		data[1] = 12;                  /* channel */
+		data[2] = 0;                   /* encryption type */
+		data[3] = (byte)(42 & 0xFF);  /* signal strength */
+		System.arraycopy(ssid, 0, data, 4, ssid.length);
+		PowerMockito.doReturn(50).when(wifiDevice, METHOD_GET_SIGNAL_QUALITY, Mockito.anyInt(), Mockito.anyInt());
+		
+		// Call the method under test.
+		AccessPoint parsedAccessPoint = Whitebox.invokeMethod(wifiDevice, METHOD_PARSE_DISCOVERED_ACCESS_POINT, data);
+		
+		// Verify the result.
+		assertThat("Parsed access point should equal the mocked one", parsedAccessPoint, is(equalTo(mockedAccessPoint)));
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(1)).invoke(METHOD_GET_SIGNAL_QUALITY, 2, 42 & 0xFF);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#getSignalQuality(int, int)}.
+	 * 
+	 * <p>Verify that when Wi-Fi version is 1, the signal quality is generated correctly.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testGetSignalQualityVersion1() throws Exception {
+		// Setup the resources for the test.
+		int signal1 = -150;
+		int signal2 = -80;
+		int signal3 = -60;
+		int signal4 = 40;
+		
+		// Call the method under test.
+		int quality1 = Whitebox.invokeMethod(wifiDevice, METHOD_GET_SIGNAL_QUALITY, 1, signal1);
+		int quality2 = Whitebox.invokeMethod(wifiDevice, METHOD_GET_SIGNAL_QUALITY, 1, signal2);
+		int quality3 = Whitebox.invokeMethod(wifiDevice, METHOD_GET_SIGNAL_QUALITY, 1, signal3);
+		int quality4 = Whitebox.invokeMethod(wifiDevice, METHOD_GET_SIGNAL_QUALITY, 1, signal4);
+		
+		// Verify the result.
+		assertThat("quality1 should be 0", quality1, is(equalTo(0)));
+		assertThat("quality2 should be 40", quality2, is(equalTo(40)));
+		assertThat("quality3 should be 80", quality3, is(equalTo(80)));
+		assertThat("quality4 should be 100", quality4, is(equalTo(100)));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#getSignalQuality(int, int)}.
+	 * 
+	 * <p>Verify that when Wi-Fi version is 2, the signal quality is generated correctly.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testGetSignalQualityVersion2() throws Exception {
+		// Setup the resources for the test.
+		int signal1 = -20;
+		int signal2 = 20;
+		int signal3 = 40;
+		int signal4 = 60;
+		
+		// Call the method under test.
+		int quality1 = Whitebox.invokeMethod(wifiDevice, METHOD_GET_SIGNAL_QUALITY, 2, signal1);
+		int quality2 = Whitebox.invokeMethod(wifiDevice, METHOD_GET_SIGNAL_QUALITY, 2, signal2);
+		int quality3 = Whitebox.invokeMethod(wifiDevice, METHOD_GET_SIGNAL_QUALITY, 2, signal3);
+		int quality4 = Whitebox.invokeMethod(wifiDevice, METHOD_GET_SIGNAL_QUALITY, 2, signal4);
+		
+		// Verify the result.
+		assertThat("quality1 should be 0", quality1, is(equalTo(0)));
+		assertThat("quality2 should be 40", quality2, is(equalTo(40)));
+		assertThat("quality3 should be 80", quality3, is(equalTo(80)));
+		assertThat("quality4 should be 100", quality4, is(equalTo(100)));
+	}
+	
+	/**
+	 * Helper method to create AS responses.
+	 * 
+	 * @param frameId Frame ID for the generated packet.
+	 * @param status Status code of the packet.
+	 * @param version Wi-Fi protocol version of the module.
+	 * @param channel Operating channel.
+	 * @param encryptionType Wi-Fi encryption type.
+	 * @param signalStrength Signal strength value.
+	 * @param ssid SSID name of the access point.
+	 * 
+	 * @return The AS AT command response packet with the access point information.
+	 */
+	private ATCommandResponsePacket createASCmdPacket(int frameId, ATCommandStatus status, 
+			int version, int channel, WiFiEncryptionType encryptionType, int signalStrength, 
+			String ssid) {
+		byte[] value = new byte[1 /* version */ + 1 /* channel */ + 1 /* encryption type */ 
+		                        + 1 /* signal strength */ + ssid.length()];
+		
+		byte[] ssidByteArray = ssid.getBytes();
+		
+		value[0] = (byte)(version & 0xFF);
+		value[1] = (byte)(channel & 0xFF);
+		value[2] = (byte)(encryptionType.getID() & 0xFF);
+		value[3] = (byte)(signalStrength & 0xFF);
+		System.arraycopy(ssidByteArray, 0, value, 4, ssidByteArray.length);
+		
+		return new ATCommandResponsePacket(frameId, status, "AS", value);
+	}
+	
+	/**
+	 * Helper method that changes the milliseconds to return when the System.currentMillis() 
+	 * method is invoked.
+	 * 
+	 * @param time The time to all to the milliseconds to return.
+	 */
+	public void changeMillisToReturn(int time) {
+		currentMillis += time;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/ConnectToAccessPointTest.java
+++ b/library/src/test/java/com/digi/xbee/api/ConnectToAccessPointTest.java
@@ -1,0 +1,653 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.digi.xbee.api.connection.IConnectionInterface;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.XBeeException;
+import com.digi.xbee.api.models.AccessPoint;
+import com.digi.xbee.api.models.OperatingMode;
+import com.digi.xbee.api.models.WiFiEncryptionType;
+
+@PrepareForTest({WiFiDevice.class, System.class})
+@RunWith(PowerMockRunner.class)
+public class ConnectToAccessPointTest {
+	
+	// Constants.
+	private static final String METHOD_SLEEP = "sleep";
+		
+	// Variables.
+	private WiFiDevice wifiDevice;
+	
+	private IConnectionInterface cInterfaceMock;
+	
+	private long currentMillis = 0;
+	
+	private AccessPoint mockedAccessPoint;
+	
+	@Before
+	public void setUp() throws Exception {
+		cInterfaceMock = PowerMockito.mock(IConnectionInterface.class);
+		wifiDevice = PowerMockito.spy(new WiFiDevice(cInterfaceMock));
+		mockedAccessPoint = PowerMockito.mock(AccessPoint.class);
+		PowerMockito.doReturn("").when(mockedAccessPoint).getSSID();
+		PowerMockito.doReturn(WiFiEncryptionType.NONE).when(mockedAccessPoint).getEncryptionType();
+		
+		PowerMockito.when(wifiDevice.isOpen()).thenReturn(true);
+		PowerMockito.when(wifiDevice.getOperatingMode()).thenReturn(OperatingMode.API);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#disconnect()}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot disconnect from the access point 
+	 * if the device is not open throwing an {@code InterfaceNotOpenException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public final void testDisconnectDeviceNotOpen() throws XBeeException {
+		// Setup the resources for the test.
+		PowerMockito.doThrow(new InterfaceNotOpenException()).when(wifiDevice).executeParameter(Mockito.anyString());
+		
+		// Call the method under test.
+		wifiDevice.disconnect();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#disconnect()}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot disconnect from the access point 
+	 * if the device is in AT mode throwing an {@code InvalidOperatingModeException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public final void testDisconnectInvalidOperatingMode() throws XBeeException {
+		// Setup the resources for the test.
+		PowerMockito.doThrow(new InvalidOperatingModeException()).when(wifiDevice).executeParameter(Mockito.anyString());
+		
+		// Call the method under test.
+		wifiDevice.disconnect();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#disconnect()}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot disconnect from the access point 
+	 * if there is a timeout sending the NR command throwing a {@code TimeoutException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public final void testDisconnectTimeout() throws XBeeException {
+		// Setup the resources for the test.
+		PowerMockito.doThrow(new TimeoutException()).when(wifiDevice).executeParameter(Mockito.anyString());
+		
+		// Call the method under test.
+		wifiDevice.disconnect();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#disconnect()}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot disconnect from the access point 
+	 * if the AI status is {@code null}.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testDisconnectNullAIStatus() throws Exception {
+		// Setup the resources for the test.
+		PowerMockito.doNothing().when(wifiDevice).executeParameter("NR");
+		PowerMockito.doReturn(null).when(wifiDevice).getParameter("AI");
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Configure the number of ticks (times) the sleep method should be called.
+		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean disconnected = wifiDevice.disconnect();
+		
+		// Verify the result.
+		assertThat("Module should not have disconnected", disconnected, is(equalTo(false)));
+		// Verify that the sleep method was called 'ticks' times.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(ticks)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#disconnect()}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot disconnect from the access point 
+	 * if the AI status is empty.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testDisconnectEmptyAIStatus() throws Exception {
+		// Setup the resources for the test.
+		PowerMockito.doNothing().when(wifiDevice).executeParameter("NR");
+		PowerMockito.doReturn(new byte[0]).when(wifiDevice).getParameter("AI");
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Configure the number of ticks (times) the sleep method should be called.
+		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean disconnected = wifiDevice.disconnect();
+		
+		// Verify the result.
+		assertThat("Module should not have disconnected", disconnected, is(equalTo(false)));
+		// Verify that the sleep method was called 'ticks' times.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(ticks)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#disconnect()}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot disconnect if the AI status is not 
+	 * 0x23.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testDisconnectWrongAIStatus() throws Exception {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doNothing().when(wifiDevice).executeParameter("NR");
+		PowerMockito.doReturn(new byte[0x13]).when(wifiDevice).getParameter("AI");
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Configure the number of ticks (times) the sleep method should be called.
+		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean disconnected = wifiDevice.disconnect();
+		
+		// Verify the result.
+		assertThat("Module should have not disconnected", disconnected, is(equalTo(false)));
+		// Verify that the sleep method was called 'ticks' times.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(ticks)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#disconnect()}.
+	 * 
+	 * <p>Verify that the Wi-Fi module can disconnect from the access point 
+	 * successfully.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testDisconnectSuccess() throws Exception {
+		// Setup the resources for the test.
+		PowerMockito.doNothing().when(wifiDevice).executeParameter("NR");
+		PowerMockito.doReturn(new byte[]{0x23}).when(wifiDevice).getParameter("AI");
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Configure the number of ticks (times) the sleep method should be called.
+		int ticks = 1;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean disconnected = wifiDevice.disconnect();
+		
+		// Verify the result.
+		assertThat("Module should have disconnected", disconnected, is(equalTo(true)));
+		// Verify that the sleep method was called 'ticks' times.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(ticks)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if the 
+	 * access point provided is {@code null} throwing a {@code NullPointerException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public final void testConnectAccessPointAPNull() throws XBeeException {
+		// Call the method under test.
+		wifiDevice.connect((AccessPoint)null, "");
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(String, String, int)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if the 
+	 * SSID provided is {@code null} throwing a {@code NullPointerException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=NullPointerException.class)
+	public final void testConnectAccessPointSSIDNull() throws XBeeException {
+		// Call the method under test.
+		wifiDevice.connect((String)null, "");
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(String, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if 
+	 * there is not any access point with the provided SSID throwing an 
+	 * {@code XBeeException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=XBeeException.class)
+	public final void testConnectAccessPointSSIDNotFound() throws XBeeException {
+		// Setup the resources for the test.
+		String ssid = "AP SSID";
+		
+		// Return a null access point when asked for one.
+		PowerMockito.doReturn(null).when(wifiDevice).getAccessPoint(ssid);
+		
+		// Call the method under test.
+		wifiDevice.connect(ssid, "");
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(String, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module can connect to to an access point successfully 
+	 * providing just the SSID of the access point.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test
+	public final void testConnectSuccessSSID() throws XBeeException {
+		// Setup the resources for the test.
+		String ssid = "AP SSID";
+		String password = "password";
+		
+		// Return the mocked access point when asked for one.
+		PowerMockito.doReturn(mockedAccessPoint).when(wifiDevice).getAccessPoint(ssid);
+		
+		// Return true when asked to connect to an access point.
+		PowerMockito.doReturn(true).when(wifiDevice).connect(Mockito.eq(mockedAccessPoint), Mockito.anyString());
+		
+		
+		// Call the method under test.
+		boolean connected = wifiDevice.connect(ssid, password);
+		
+		// Verify the result.
+		assertThat("Module should have connected", connected, is(equalTo(true)));
+		// Verify that the connect method was called one time.
+		Mockito.verify(wifiDevice, Mockito.times(1)).connect(Mockito.eq(mockedAccessPoint), Mockito.eq(password));
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if 
+	 * device is not open throwing an {@code InterfaceNotOpenException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public final void testConnectDeviceNotOpen() throws XBeeException {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doThrow(new InterfaceNotOpenException()).when(wifiDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		// Call the method under test.
+		wifiDevice.connect(mockedAccessPoint, "");
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if the 
+	 * device is in AT mode throwing an {@code InvalidOperatingModeException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public final void testConnectInvalidOperatingMode() throws XBeeException {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doThrow(new InvalidOperatingModeException()).when(wifiDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		// Call the method under test.
+		wifiDevice.connect(mockedAccessPoint, "");
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if there 
+	 * is a timeout setting any connection parameter throwing a {@code TimeoutException}.</p>
+	 * 
+	 * @throws XBeeException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public final void testConnectTimeout() throws XBeeException {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doThrow(new TimeoutException()).when(wifiDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		
+		// Call the method under test.
+		wifiDevice.connect(mockedAccessPoint, "");
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if the AI 
+	 * status is {@code null} and the password is not configured.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testConnectNullAIStatusNullPassword() throws Exception {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doNothing().when(wifiDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		PowerMockito.doReturn(null).when(wifiDevice).getParameter("AI");
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Configure the number of ticks (times) the sleep method should be called.
+		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean connected = wifiDevice.connect(mockedAccessPoint, null);
+		
+		// Verify the result.
+		assertThat("Module should have not connected", connected, is(equalTo(false)));
+		// Verify that the sleep method was called 'ticks' times.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(ticks)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if the AI 
+	 * status is empty and the password is not configured.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testConnectEmptyAIStatus() throws Exception {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doNothing().when(wifiDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		PowerMockito.doReturn(new byte[0]).when(wifiDevice).getParameter("AI");
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Configure the number of ticks (times) the sleep method should be called.
+		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean connected = wifiDevice.connect(mockedAccessPoint, null);
+		
+		// Verify the result.
+		assertThat("Module should have not connected", connected, is(equalTo(false)));
+		// Verify that the sleep method was called 'ticks' times.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(ticks)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module cannot connect to an access point if the AI 
+	 * status is not 0.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testConnectWrongAIStatus() throws Exception {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doNothing().when(wifiDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		PowerMockito.doReturn(new byte[]{0x23}).when(wifiDevice).getParameter("AI");
+		
+		Mockito.doReturn(WiFiEncryptionType.NONE).when(mockedAccessPoint).getEncryptionType();
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Configure the number of ticks (times) the sleep method should be called.
+		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean connected = wifiDevice.connect(mockedAccessPoint, "password");
+		
+		// Verify the result.
+		assertThat("Module should have not connected", connected, is(equalTo(false)));
+		// Verify that the sleep method was called 'ticks' times.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(ticks)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module can connect to to an access point successfully when 
+	 * the password is null.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testConnectSuccessPasswordNull() throws Exception {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doNothing().when(wifiDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		PowerMockito.doReturn(new byte[]{0}).when(wifiDevice).getParameter("AI");
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean connected = wifiDevice.connect(mockedAccessPoint, null);
+		
+		// Verify the result.
+		assertThat("Module should have connected", connected, is(equalTo(true)));
+		// Verify that the sleep method was called one time.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(1)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#connect(AccessPoint, String)}.
+	 * 
+	 * <p>Verify that the Wi-Fi module can connect to to an access point successfully when 
+	 * the password is not null.</p>
+	 * 
+	 * @throws Exception 
+	 */
+	@Test
+	public final void testConnectSuccessPasswordNotNull() throws Exception {
+		// Setup the resources for the test.
+		// Prepare the answers to the AT commands.
+		PowerMockito.doNothing().when(wifiDevice).setParameter(Mockito.anyString(), Mockito.any(byte[].class));
+		PowerMockito.doReturn(new byte[]{0x00}).when(wifiDevice).getParameter("AI");
+		
+		Mockito.doReturn(WiFiEncryptionType.WEP).when(mockedAccessPoint).getEncryptionType();
+		
+		// Get the current time.
+		currentMillis = System.currentTimeMillis();
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.mockStatic(System.class);
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+		
+		// When the sleep method is called, add 100ms to the currentMillis variable.
+		PowerMockito.doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Exception {
+				Object[] args = invocation.getArguments();
+				int sleepTime = (Integer)args[0];
+				changeMillisToReturn(sleepTime);
+				return null;
+			}
+		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
+		
+		// Call the method under test.
+		boolean connected = wifiDevice.connect(mockedAccessPoint, "password");
+		
+		// Verify the result.
+		assertThat("Module should have connected", connected, is(equalTo(true)));
+		// Verify that the sleep method was called one time.
+		PowerMockito.verifyPrivate(wifiDevice, Mockito.times(1)).invoke(METHOD_SLEEP, 100);
+	}
+	
+	/**
+	 * Helper method that changes the milliseconds to return when the System.currentMillis() 
+	 * method is invoked.
+	 * 
+	 * @param time The time to all to the milliseconds to return.
+	 */
+	public void changeMillisToReturn(int time) {
+		currentMillis += time;
+		
+		// Prepare the System class to return our fixed currentMillis variable when requested.
+		PowerMockito.when(System.currentTimeMillis()).thenReturn(currentMillis);
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/WiFiDeviceTest.java
+++ b/library/src/test/java/com/digi/xbee/api/WiFiDeviceTest.java
@@ -13,6 +13,9 @@ package com.digi.xbee.api;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
+import java.net.Inet4Address;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,6 +28,11 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.digi.xbee.api.connection.serial.SerialPortRxTx;
+import com.digi.xbee.api.exceptions.ATCommandException;
+import com.digi.xbee.api.exceptions.InterfaceNotOpenException;
+import com.digi.xbee.api.exceptions.InvalidOperatingModeException;
+import com.digi.xbee.api.exceptions.TimeoutException;
+import com.digi.xbee.api.exceptions.XBeeException;
 import com.digi.xbee.api.models.WiFiAssociationIndicationStatus;
 
 @RunWith(PowerMockRunner.class)
@@ -67,5 +75,141 @@ public class WiFiDeviceTest {
 		Mockito.doReturn(RESPONSE_AI).when(wifiDevice).getParameter(PARAMETER_AI);
 		
 		assertEquals(validWiFiAIStatus, wifiDevice.getWiFiAssociationIndicationStatus());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#isConnected()}.
+	 * 
+	 * <p>Verify that it is not possible to determine if the device is connected if 
+	 * the connection of the device is closed.</p>
+	 * 
+	 * @throws XBeeException
+	 */
+	@Test(expected=InterfaceNotOpenException.class)
+	public void testIsConnectedErrorConnectionClosed() throws XBeeException {
+		// Throw an interface not open exception when getting the WiFiAssociationIndicationStatus.
+		Mockito.doThrow(new InterfaceNotOpenException()).when(wifiDevice).getWiFiAssociationIndicationStatus();
+		
+		// Check the connection.
+		wifiDevice.isConnected();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#isConnected()}.
+	 * 
+	 * <p>Verify that it is not possible to determine if the device is connected if 
+	 * the operating mode of the device is not valid.</p>
+	 * 
+	 * @throws XBeeException
+	 */
+	@Test(expected=InvalidOperatingModeException.class)
+	public void testIsConnectedErrorInvalidOperatingMode() throws XBeeException {
+		// Throw an invalid operating mode exception when getting the WiFiAssociationIndicationStatus.
+		Mockito.doThrow(new InvalidOperatingModeException()).when(wifiDevice).getWiFiAssociationIndicationStatus();
+		
+		// Check the connection.
+		wifiDevice.isConnected();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#isConnected()}.
+	 * 
+	 * <p>Verify that it is not possible to determine if the device is connected 
+	 * when there is an Timeout exception getting the WiFiAssociationIndicationStatus.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test(expected=TimeoutException.class)
+	public void testIsConnectedErrorTimeout() throws XBeeException, IOException {
+		// Throw a timeout exception when getting the WiFiAssociationIndicationStatus.
+		Mockito.doThrow(new TimeoutException()).when(wifiDevice).getWiFiAssociationIndicationStatus();
+		
+		// Check the connection.
+		wifiDevice.isConnected();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#isConnected()}.
+	 * 
+	 * <p>Verify that it is not possible to determine if the device is connected 
+	 * when there is an AT command exception getting the WiFiAssociationIndicationStatus.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException 
+	 */
+	@Test(expected=ATCommandException.class)
+	public void testIsConnectedErrorInvalidAnswer() throws XBeeException, IOException {
+		// Throw an AT command exception when when getting the WiFiAssociationIndicationStatus.
+		Mockito.doThrow(new ATCommandException(null)).when(wifiDevice).getWiFiAssociationIndicationStatus();
+		
+		// Check the connection.
+		wifiDevice.isConnected();
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#isConnected()}.
+	 * 
+	 * <p>Verify that it is possible to determine if the device is connected or not 
+	 * when it is connected.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException
+	 */
+	@Test
+	public void testIsConnectedSuccessConnected() throws XBeeException, IOException {
+		// Return the connected value when when getting the WiFiAssociationIndicationStatus.
+		Mockito.doReturn(WiFiAssociationIndicationStatus.SUCCESSFULLY_JOINED).when(wifiDevice).getWiFiAssociationIndicationStatus();
+		
+		// Check the connection.
+		assertTrue(wifiDevice.isConnected());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#isConnected()}.
+	 * 
+	 * <p>Verify that it is possible to determine if the device is connected or not 
+	 * when it is disconnected.</p>
+	 * 
+	 * @throws XBeeException
+	 * @throws IOException
+	 */
+	@Test
+	public void testIsConnectedSuccessDisconnected() throws XBeeException, IOException {
+		// Return a valid disconnected value when when getting the WiFiAssociationIndicationStatus.
+		Mockito.doReturn(WiFiAssociationIndicationStatus.WAITING_FOR_IP).when(wifiDevice).getWiFiAssociationIndicationStatus();
+		
+		// Check the connection.
+		assertFalse(wifiDevice.isConnected());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#setWiFiReceiveTimeout(int)}.
+	 * 
+	 * <p>Check that the Wi-Fi receive timeout cannot be set if it is negative throwing an 
+	 * {@code IllegalArgumentException}.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetWiFiReceiveTimeoutNegative() {
+		// Call the method under test.
+		wifiDevice.setWiFiReceiveTimeout(-50);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#setWiFiReceiveTimeout(int)} and 
+	 * {@link com.digi.xbee.api.WiFiDevice#getWiFiReceiveTimeout()}.
+	 * 
+	 * <p>Check that the Wi-Fi receive timeout can be set and get successfully.</p>
+	 */
+	@Test
+	public void testSetWiFiReceiveTimeoutSuccess() {
+		// First, verify that the timeout has the default value before changing it. 
+		assertEquals(15000, wifiDevice.getWiFiReceiveTimeout());
+		
+		// Call the method under test (change the timeout).
+		wifiDevice.setWiFiReceiveTimeout(5000);
+		
+		// First, verify that the new valu was set. 
+		assertEquals(5000, wifiDevice.getWiFiReceiveTimeout());
 	}
 }

--- a/library/src/test/java/com/digi/xbee/api/models/AccessPointTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/AccessPointTest.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class AccessPointTest {
+
+	// Constants.
+	private static final String SSID = "My Access Point";
+	private static final WiFiEncryptionType ENCRYPTION_TYPE = WiFiEncryptionType.WEP;
+	private static final int CHANNEL = 12;
+	private static final int SIGNAL_QUALITY = 75;
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType)}.
+	 * 
+	 * <p>Verify that the {@code AccessPoint} cannot be created if the SSID is null.</p>
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testCreateNullSSID() {
+		new AccessPoint(null, ENCRYPTION_TYPE);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType)}.
+	 * 
+	 * <p>Verify that the {@code AccessPoint} cannot be created if the encryption type is null.</p>
+	 */
+	@Test(expected=NullPointerException.class)
+	public void testCreateNullEncryptionType() {
+		new AccessPoint(SSID, null);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType)}.
+	 * 
+	 * <p>Verify that the {@code AccessPoint} cannot be created if the length of the SSID is 0.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testCreateIllegalSSIDEmpty() {
+		new AccessPoint("", ENCRYPTION_TYPE);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType, int, int)}.
+	 * 
+	 * <p>Verify that the {@code AccessPoint} cannot be created if the length of the SSID is 0.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testCreateIllegalChannelNegative() {
+		new AccessPoint(SSID, ENCRYPTION_TYPE, -5, 0);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType, int, int)}.
+	 * 
+	 * <p>Verify that the {@code AccessPoint} cannot be created if the signal quality is negative.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testCreateIllegalSignalQualityNegative() {
+		new AccessPoint(SSID, ENCRYPTION_TYPE, CHANNEL, -10);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType, int, int)}.
+	 * 
+	 * <p>Verify that the {@code AccessPoint} cannot be created if the signal quality is 
+	 * greater than 100.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testCreateIllegalSignalQualityBIG() {
+		new AccessPoint(SSID, ENCRYPTION_TYPE, CHANNEL, 150);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType)}, 
+	 * {@link com.digi.xbee.api.models.AccessPoint#getSSID()},
+	 * {@link com.digi.xbee.api.models.AccessPoint#getEncryptionKey()}.
+	 * 
+	 * <p>Verify that the {@code AccessPoint} can be created successfully and the getters work 
+	 * properly when the channel signal quality are not provided.</p>
+	 */
+	@Test
+	public void testCreateSuccessNotChannelSignalQuality() {
+		AccessPoint accessPoint = new AccessPoint(SSID, ENCRYPTION_TYPE);
+		
+		String accessPointString = SSID + " (" + ENCRYPTION_TYPE.name() + ") - CH: 0 - Signal: 0%";
+		
+		assertEquals(SSID, accessPoint.getSSID());
+		assertEquals(ENCRYPTION_TYPE, accessPoint.getEncryptionType());
+		assertEquals(0, accessPoint.getSignalQuality());
+		assertEquals(accessPointString, accessPoint.toString());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType, int, int)}, 
+	 * {@link com.digi.xbee.api.models.AccessPoint#getSSID()},
+	 * {@link com.digi.xbee.api.models.AccessPoint#getEncryptionKey()},
+	 * {@link com.digi.xbee.api.models.AccessPoint#getChannel()}, 
+	 * {@link com.digi.xbee.api.models.AccessPoint#getSignalQuality()}.
+	 * 
+	 * <p>Verify that the {@code AccessPoint} can be created successfully and the getters work 
+	 * properly when the channel and signal quality are provided.</p>
+	 */
+	@Test
+	public void testCreateSuccess() {
+		AccessPoint accessPoint = new AccessPoint(SSID, ENCRYPTION_TYPE, CHANNEL, SIGNAL_QUALITY);
+		
+		String accessPointString = SSID + " (" + ENCRYPTION_TYPE.name() + ") - CH: " + CHANNEL + " - Signal: " + SIGNAL_QUALITY + "%";
+		
+		assertEquals(SSID, accessPoint.getSSID());
+		assertEquals(ENCRYPTION_TYPE, accessPoint.getEncryptionType());
+		assertEquals(CHANNEL, accessPoint.getChannel());
+		assertEquals(SIGNAL_QUALITY, accessPoint.getSignalQuality());
+		assertEquals(accessPointString, accessPoint.toString());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType, int)}, 
+	 * {@link com.digi.xbee.api.models.AccessPoint#getSignalQuality()},
+	 * {@link com.digi.xbee.api.models.AccessPoint#setSignalQuality(int)}.
+	 * 
+	 * <p>Verify that the signal quality cannot be set if it is negative.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetSignalQualityNegative() {
+		AccessPoint accessPoint = new AccessPoint(SSID, ENCRYPTION_TYPE);
+		
+		accessPoint.setSignalQuality(-10);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType, int)}, 
+	 * {@link com.digi.xbee.api.models.AccessPoint#getSignalQuality()},
+	 * {@link com.digi.xbee.api.models.AccessPoint#setSignalQuality(int)}.
+	 * 
+	 * <p>Verify that the signal quality cannot be set if it is greater than 100.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetSignalQualityBIG() {
+		AccessPoint accessPoint = new AccessPoint(SSID, ENCRYPTION_TYPE);
+		
+		accessPoint.setSignalQuality(150);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType, int)}, 
+	 * {@link com.digi.xbee.api.models.AccessPoint#setSignalQuality(int)},
+	 * {@link com.digi.xbee.api.models.AccessPoint#getSignalQuality()}.
+	 * 
+	 * <p>Verify that the signal quality can be set and get successfully.</p>
+	 */
+	@Test
+	public void testSetSignalQualitySuccess() {
+		AccessPoint accessPoint = new AccessPoint(SSID, ENCRYPTION_TYPE);
+		
+		assertEquals(0, accessPoint.getSignalQuality());
+		accessPoint.setSignalQuality(SIGNAL_QUALITY);
+		assertEquals(SIGNAL_QUALITY, accessPoint.getSignalQuality());
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType)}, 
+	 * {@link com.digi.xbee.api.models.AccessPoint#getChannel()},
+	 * {@link com.digi.xbee.api.models.AccessPoint#setChannel(int)}.
+	 * 
+	 * <p>Verify that the channel cannot be set if it is negative.</p>
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetChannelNegative() {
+		AccessPoint accessPoint = new AccessPoint(SSID, ENCRYPTION_TYPE);
+		
+		accessPoint.setChannel(-10);
+	}
+	
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.AccessPoint#AccessPoint(String, WiFiEncryptionType)}, 
+	 * {@link com.digi.xbee.api.models.AccessPoint#setChannel(int)},
+	 * {@link com.digi.xbee.api.models.AccessPoint#getChannel()}.
+	 * 
+	 * <p>Verify that the channel can be set and get successfully.</p>
+	 */
+	@Test
+	public void testSetChannelSuccess() {
+		AccessPoint accessPoint = new AccessPoint(SSID, ENCRYPTION_TYPE);
+		
+		assertEquals(0, accessPoint.getChannel());
+		accessPoint.setChannel(CHANNEL);
+		assertEquals(CHANNEL, accessPoint.getChannel());
+	}
+}

--- a/library/src/test/java/com/digi/xbee/api/models/WiFiEncryptionTypeTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/WiFiEncryptionTypeTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+package com.digi.xbee.api.models;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class WiFiEncryptionTypeTest {
+
+	// Variables.
+	private WiFiEncryptionType[] encryptionTypeValues;
+
+	@Before
+	public void setup() {
+		// Retrieve the list of enum. values.
+		encryptionTypeValues = WiFiEncryptionType.values();
+	}
+
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiEncryptionType#getID()}.
+	 *
+	 * <p>Verify that the ID of each {@code WiFiEncryptionType} entry is valid.</p>
+	 */
+	@Test
+	public void testWiFiEncryptionTypeEnumValues() {
+		for (WiFiEncryptionType encryptionType:encryptionTypeValues)
+			assertTrue(encryptionType.getID() >= 0);
+	}
+
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiEncryptionType#name()}.
+	 *
+	 * <p>Verify that the name of each {@code WiFiEncryptionType} entry is valid.
+	 * </p>
+	 */
+	@Test
+	public void testWiFiEncryptionTypeEnumNames() {
+		for (WiFiEncryptionType encryptionType:encryptionTypeValues) {
+			assertNotNull(encryptionType.name());
+			assertTrue(encryptionType.name().length() > 0);
+		}
+	}
+
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiEncryptionType#get(int)}.
+	 *
+	 * <p>Verify that each {@code WiFiEncryptionType} entry can be retrieved
+	 * statically using its value.</p>
+	 */
+	@Test
+	public void testWiFiEncryptionTypeStaticAccess() {
+		for (WiFiEncryptionType encryptionType:encryptionTypeValues)
+			assertEquals(encryptionType, WiFiEncryptionType.get(encryptionType.getID()));
+	}
+
+	/**
+	 * Test method for {@link com.digi.xbee.api.models.WiFiEncryptionType#toString()}.
+	 *
+	 * <p>Verify that the {@code toString()} method of a {@code WiFiEncryptionType}
+	 * entry returns its description correctly.</p>
+	 */
+	@Test
+	public void testWiFiEncryptionTypeToString() {
+		for (WiFiEncryptionType encryptionType:encryptionTypeValues)
+			assertEquals(encryptionType.getName(), encryptionType.toString());
+	}
+}


### PR DESCRIPTION
- Added a new enumerator (WiFiAssociationIndicationStatus) to list the
  possible encryption types for the Wi-Fi access points.
- Added the AccessPoint class that represents an access point.
- Added new methods to discover access points, get a specific one, connect
  and disconnect.
- Added new methods to get and set the Wi-Fi receive timeout, used to
  connect, disconnect and discover access points.
- Written the unit tests for the new code and updated some others.

Signed-off-by: Diego Escalona <diego.escalona@digi.com>