### PR TITLE
wifi: rename discover access points and Wi-Fi receive timeout methods

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/IPDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/IPDevice.java
@@ -29,7 +29,6 @@ import com.digi.xbee.api.models.XBee16BitAddress;
 import com.digi.xbee.api.models.XBee64BitAddress;
 import com.digi.xbee.api.models.XBeeMessage;
 import com.digi.xbee.api.models.XBeePacketsQueue;
-import com.digi.xbee.api.models.XBeeTransmitOptions;
 import com.digi.xbee.api.packet.XBeeAPIPacket;
 import com.digi.xbee.api.packet.XBeePacket;
 import com.digi.xbee.api.packet.ip.RXIPv4Packet;

--- a/library/src/main/java/com/digi/xbee/api/WiFiDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/WiFiDevice.java
@@ -51,7 +51,7 @@ import com.digi.xbee.api.utils.ByteUtils;
 public class WiFiDevice extends IPDevice {
 	
 	// Constants.
-	private final static int DEFAULT_WIFI_RECEIVE_TIMETOUT = 15000; // 15 seconds of timeout to connect, disconnect and discover access points.
+	private final static int DEFAULT_ACCESS_POINT_TIMETOUT = 15000; // 15 seconds of timeout to connect, disconnect and scan access points.
 	
 	private static final String AS_COMMAND = "AS";
 	private static final String ERROR_ALREADY_CONNECTED = "Device is already connected to an access point.";
@@ -59,10 +59,10 @@ public class WiFiDevice extends IPDevice {
 	private static final int DISCOVER_TIMEOUT = 30000;
 	
 	// Variables.
-	private boolean discoveringAccessPoints = false;
-	private boolean discoveringAccessPointsError = false;
+	private boolean scanningAccessPoints = false;
+	private boolean scanningAccessPointsError = false;
 	
-	protected int wifiReceiveTimeout = DEFAULT_WIFI_RECEIVE_TIMETOUT;
+	protected int accessPointTimeout = DEFAULT_ACCESS_POINT_TIMETOUT;
 	
 	/**
 	 * Class constructor. Instantiates a new {@code WiFiDevice} object in 
@@ -189,14 +189,14 @@ public class WiFiDevice extends IPDevice {
 	}
 	
 	/**
-	 * Discovers and reports the access point that matches the supplied SSID.
+	 * Finds and reports the access point that matches the supplied SSID.
 	 * 
 	 * <p>This method blocks until the access point is discovered or the 
-	 * configured Wi-Fi receive timeout expires.</p>
+	 * configured access point timeout expires.</p>
 	 * 
-	 * <p>The Wi-Fi receive timeout is configured using the 
-	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
-	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * <p>The access point timeout is configured using the 
+	 * {@code setAccessPointTimeout} method and can be consulted with 
+	 * {@code getAccessPointTimeout} method.</p>
 	 * 
 	 * @param ssid The SSID of the access point to discover.
 	 * 
@@ -208,9 +208,9 @@ public class WiFiDevice extends IPDevice {
 	 * @throws TimeoutException if there is a timeout getting the access point.
 	 * @throws XBeeException if there is an error sending the discovery command.
 	 * 
-	 * @see #discoverAccessPoints()
-	 * @see #getWiFiReceiveTimeout()
-	 * @see #setWiFiReceiveTimeout(int)
+	 * @see #getAccessPointTimeout()
+	 * @see #scanAccessPoints()
+	 * @see #setAccessPointTimeout(int)
 	 */
 	public AccessPoint getAccessPoint(String ssid) throws XBeeException {
 		if (ssid == null)
@@ -218,7 +218,7 @@ public class WiFiDevice extends IPDevice {
 		
 		logger.debug("{}AS for '{}' access point.", toString(), ssid);
 		
-		List<AccessPoint> accessPointsList = discoverAccessPoints();
+		List<AccessPoint> accessPointsList = scanAccessPoints();
 		
 		for (AccessPoint accessPoint:accessPointsList) {
 			if (accessPoint.getSSID().equals(ssid))
@@ -229,26 +229,26 @@ public class WiFiDevice extends IPDevice {
 	}
 	
 	/**
-	 * Performs a discovery to search for access points in the vicinity.
+	 * Performs a scan to search for access points in the vicinity.
 	 * 
 	 * <p>This method blocks until all the access points are discovered or the 
-	 * configured Wi-Fi receive timeout expires.</p>
+	 * configured access point timeout expires.</p>
 	 * 
-	 * <p>The Wi-Fi receive timeout is configured using the 
-	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
-	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * <p>The access point timeout is configured using the 
+	 * {@code setAccessPointTimeout} method and can be consulted with 
+	 * {@code getAccessPointTimeout} method.</p>
 	 * 
 	 * @return The list of access points discovered.
 	 * 
 	 * @throws InterfaceNotOpenException if this device connection is not open.
-	 * @throws TimeoutException if there is a timeout discovering the access points.
+	 * @throws TimeoutException if there is a timeout scanning the access points.
 	 * @throws XBeeException if there is any other XBee related exception.
 	 * 
 	 * @see #getAccessPoint(String)
-	 * @see #getWiFiReceiveTimeout()
-	 * @see #setWiFiReceiveTimeout(int)
+	 * @see #getAccessPointTimeout()
+	 * @see #setAccessPointTimeout(int)
 	 */
-	public List<AccessPoint> discoverAccessPoints() throws XBeeException {
+	public List<AccessPoint> scanAccessPoints() throws XBeeException {
 		// Check if the connection is open.
 		if (!isOpen())
 			throw new InterfaceNotOpenException();
@@ -270,7 +270,7 @@ public class WiFiDevice extends IPDevice {
 				 */
 				@Override
 				public void packetReceived(XBeePacket receivedPacket) {
-					if (!discoveringAccessPoints)
+					if (!scanningAccessPoints)
 						return;
 					
 					try {
@@ -282,12 +282,12 @@ public class WiFiDevice extends IPDevice {
 						
 						// Check for error.
 						if (response.getStatus() == ATCommandStatus.ERROR) {
-							discoveringAccessPointsError = true;
-							discoveringAccessPoints = false;
+							scanningAccessPointsError = true;
+							scanningAccessPoints = false;
 						// Check for end of discovery.
 						} else if (response.getCommandValue() == null 
 								|| response.getCommandValue().length == 0)
-							discoveringAccessPoints = false;
+							scanningAccessPoints = false;
 						else {
 							AccessPoint accessPoint = parseDiscoveredAccessPoint(response.getCommandValue());
 							if (accessPoint != null)
@@ -299,30 +299,30 @@ public class WiFiDevice extends IPDevice {
 				}
 			};
 			
-			logger.debug("{}Start discovering access points.", toString());
+			logger.debug("{}Start scanning access points.", toString());
 			addPacketListener(packetReceiveListener);
 			
 			try {
-				discoveringAccessPoints = true;
+				scanningAccessPoints = true;
 				// Send the active scan command.
 				sendPacketAsync(new ATCommandPacket(getNextFrameID(), AS_COMMAND, ""));
 				
 				// Wait until the discovery process finishes or timeouts.
 				long deadLine = System.currentTimeMillis() + DISCOVER_TIMEOUT;
-				while (discoveringAccessPoints && System.currentTimeMillis() < deadLine)
+				while (scanningAccessPoints && System.currentTimeMillis() < deadLine)
 					sleep(100);
 				
 				// Check if we exited because of a timeout.
-				if (discoveringAccessPoints)
+				if (scanningAccessPoints)
 					throw new TimeoutException();
 				// Check if there was an error in the active scan command (device is already connected).
-				if (discoveringAccessPointsError)
+				if (scanningAccessPointsError)
 					throw new XBeeException(ERROR_ALREADY_CONNECTED);
 			} finally {
-				discoveringAccessPoints = false;
-				discoveringAccessPointsError = false;
+				scanningAccessPoints = false;
+				scanningAccessPointsError = false;
 				removePacketListener(packetReceiveListener);
-				logger.debug("{}Stop discovering access points.", toString());
+				logger.debug("{}Stop scanning access points.", toString());
 			}
 		}
 		
@@ -333,11 +333,11 @@ public class WiFiDevice extends IPDevice {
 	 * Connects to the access point with provided SSID.
 	 * 
 	 * <p>This method blocks until the connection with the access point is 
-	 * established or the configured Wi-Fi receive timeout expires.</p>
+	 * established or the configured access point timeout expires.</p>
 	 * 
-	 * <p>The Wi-Fi receive timeout is configured using the 
-	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
-	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * <p>The access point timeout is configured using the 
+	 * {@code setAccessPointTimeout} method and can be consulted with 
+	 * {@code getAccessPointTimeout} method.</p>
 	 * 
 	 * <p>Once the module is connected to the access point, you can issue 
 	 * the {@link #writeChanges()} method to save the connection settings. This 
@@ -360,10 +360,10 @@ public class WiFiDevice extends IPDevice {
 	 * 
 	 * @see #connect(AccessPoint, String)
 	 * @see #disconnect()
-	 * @see #discoverAccessPoints()
 	 * @see #getAccessPoint(String)
-	 * @see #getWiFiReceiveTimeout()
-	 * @see #setWiFiReceiveTimeout(int)
+	 * @see #getAccessPointTimeout()
+	 * @see #scanAccessPoints()
+	 * @see #setAccessPointTimeout(int)
 	 */
 	public boolean connect(String ssid, String password) 
 			throws TimeoutException, XBeeException {
@@ -381,11 +381,11 @@ public class WiFiDevice extends IPDevice {
 	 * Connects to the provided access point.
 	 * 
 	 * <p>This method blocks until the connection with the access point is 
-	 * established or the configured Wi-Fi receive timeout expires.</p>
+	 * established or the configured access point timeout expires.</p>
 	 * 
-	 * <p>The Wi-Fi receive timeout is configured using the 
-	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
-	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * <p>The access point timeout is configured using the 
+	 * {@code setAccessPointTimeout} method and can be consulted with 
+	 * {@code getAccessPointTimeout} method.</p>
 	 * 
 	 * <p>Once the module is connected to the access point, you can issue 
 	 * the {@code writeSettings} method to save the connection settings. This 
@@ -407,10 +407,10 @@ public class WiFiDevice extends IPDevice {
 	 * 
 	 * @see #connect(String, String)
 	 * @see #disconnect()
-	 * @see #discoverAccessPoints()
 	 * @see #getAccessPoint(String)
-	 * @see #getWiFiReceiveTimeout()
-	 * @see #setWiFiReceiveTimeout(int)
+	 * @see #getAccessPointTimeout()
+	 * @see #scanAccessPoints()
+	 * @see #setAccessPointTimeout(int)
 	 * @see com.digi.xbee.api.models.AccessPoint
 	 */
 	public boolean connect(AccessPoint accessPoint, String password) 
@@ -425,7 +425,7 @@ public class WiFiDevice extends IPDevice {
 			setParameter("PK", password.getBytes());
 		
 		// Wait for the module to connect to the access point.
-		long deadLine = System.currentTimeMillis() + wifiReceiveTimeout;
+		long deadLine = System.currentTimeMillis() + accessPointTimeout;
 		while (System.currentTimeMillis() < deadLine) {
 			sleep(100);
 			// Get the association indication value of the module.
@@ -443,11 +443,11 @@ public class WiFiDevice extends IPDevice {
 	 * Disconnects from the access point the device is connected to.
 	 * 
 	 * <p>This method blocks until the device disconnects totally from the 
-	 * access point or the configured Wi-Fi receive timeout expires.</p>
+	 * access point or the configured access point timeout expires.</p>
 	 * 
-	 * <p>The Wi-Fi receive timeout is configured using the 
-	 * {@code setWiFiReceiveTimeout} method and can be consulted with 
-	 * {@code getWiFiReceiveTimeout} method.</p>
+	 * <p>The access point timeout is configured using the 
+	 * {@code setAccessPointTimeout} method and can be consulted with 
+	 * {@code getAccessPointTimeout} method.</p>
 	 * 
 	 * @return {@code true} if the module disconnected from the access point 
 	 *         successfully, {@code false} otherwise.
@@ -459,13 +459,13 @@ public class WiFiDevice extends IPDevice {
 	 * 
 	 * @see #connect(AccessPoint, String, int)
 	 * @see #connect(String, String, int)
-	 * @see #getWiFiReceiveTimeout()
-	 * @see #setWiFiReceiveTimeout(int)
+	 * @see #getAccessPointTimeout()
+	 * @see #setAccessPointTimeout(int)
 	 */
 	public boolean disconnect() throws TimeoutException, XBeeException {
 		executeParameter("NR");
 		// Wait for the module to connect to the access point.
-		long deadLine = System.currentTimeMillis() + wifiReceiveTimeout;
+		long deadLine = System.currentTimeMillis() + accessPointTimeout;
 		while (System.currentTimeMillis() < deadLine) {
 			sleep(100);
 			// Get the association indication value of the module.
@@ -598,32 +598,32 @@ public class WiFiDevice extends IPDevice {
 	}
 	
 	/**
-	 * Returns the Wi-Fi configured timeout for connecting, disconnecting and 
-	 * discovering access points.
+	 * Returns the configured access point timeout for connecting, 
+	 * disconnecting and scanning access points.
 	 * 
-	 * @return The current Wi-Fi receive timeout in milliseconds.
+	 * @return The current access point timeout in milliseconds.
 	 * 
-	 * @see #setWiFiReceiveTimeout(int)
+	 * @see #setAccessPointTimeout(int)
 	 */
-	public int getWiFiReceiveTimeout() {
-		return wifiReceiveTimeout;
+	public int getAccessPointTimeout() {
+		return accessPointTimeout;
 	}
 	
 	/**
-	 * Configures the Wi-Fi timeout in milliseconds connecting, disconnecting 
-	 * and discovering access points.
+	 * Configures the access point timeout in milliseconds for connecting, 
+	 * disconnecting and scanning access points.
 	 *  
-	 * @param wifiReceiveTimeout The new Wi-Fi receive timeout in milliseconds.
+	 * @param accessPointTimeout The new access point timeout in milliseconds.
 	 * 
-	 * @throws IllegalArgumentException if {@code wifiReceiveTimeout < 0}.
+	 * @throws IllegalArgumentException if {@code accessPointTimeout < 0}.
 	 * 
-	 * @see #getWiFiReceiveTimeout()
+	 * @see #getAccessPointTimeout()
 	 */
-	public void setWiFiReceiveTimeout(int wifiReceiveTimeout) {
-		if (wifiReceiveTimeout < 0)
-			throw new IllegalArgumentException("Wi-Fi receive timeout cannot be less than 0.");
+	public void setAccessPointTimeout(int accessPointTimeout) {
+		if (accessPointTimeout < 0)
+			throw new IllegalArgumentException("Access point timeout cannot be less than 0.");
 		
-		this.wifiReceiveTimeout = wifiReceiveTimeout;
+		this.accessPointTimeout = accessPointTimeout;
 	}
 	
 	/**

--- a/library/src/test/java/com/digi/xbee/api/AccessPointsScanTest.java
+++ b/library/src/test/java/com/digi/xbee/api/AccessPointsScanTest.java
@@ -50,10 +50,10 @@ import com.digi.xbee.api.packet.common.ReceivePacket;
 
 @PrepareForTest({WiFiDevice.class, XBee64BitAddress.class, XBee16BitAddress.class})
 @RunWith(PowerMockRunner.class)
-public class AccessPointsDiscoverTest {
+public class AccessPointsScanTest {
 	
 	// Constants.
-	private static final String METHOD_DISCOVER_ACCESS_POINTS = "discoverAccessPoints";
+	private static final String METHOD_SCAN_ACCESS_POINTS = "scanAccessPoints";
 	private static final String METHOD_PARSE_DISCOVERED_ACCESS_POINT = "parseDiscoveredAccessPoint";
 	private static final String METHOD_GET_SIGNAL_QUALITY = "getSignalQuality";
 	private static final String METHOD_PARSE_DISCOVERED_AP = "parseDiscoveredAccessPoint";
@@ -116,7 +116,7 @@ public class AccessPointsDiscoverTest {
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#scanAccessPoints()}.
 	 * 
 	 * <p>An {@code InterfaceNotOpenException} exception must be thrown when 
 	 * the local device connection is not open.</p>
@@ -124,16 +124,16 @@ public class AccessPointsDiscoverTest {
 	 * @throws XBeeException 
 	 */
 	@Test(expected=InterfaceNotOpenException.class)
-	public final void testDiscoverAccessPointsDeviceNotOpen() throws XBeeException {
+	public final void testScanAccessPointsDeviceNotOpen() throws XBeeException {
 		// Setup the resources for the test.
 		PowerMockito.when(wifiDevice.isOpen()).thenReturn(false);
 		
 		// Call the method under test.
-		wifiDevice.discoverAccessPoints();
+		wifiDevice.scanAccessPoints();
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#scanAccessPoints()}.
 	 * 
 	 * <p>An {@code InvalidOperatingModeException} exception must be thrown when 
 	 * the local device operating mode is different than API or API Escaped.</p>
@@ -141,12 +141,12 @@ public class AccessPointsDiscoverTest {
 	 * @throws XBeeException 
 	 */
 	@Test(expected=InvalidOperatingModeException.class)
-	public final void testDiscoverAccessPointsInvalidOperatingMode() throws XBeeException {
+	public final void testScanAccessPointsInvalidOperatingMode() throws XBeeException {
 		// Setup the resources for the test.
 		PowerMockito.when(wifiDevice.getOperatingMode()).thenReturn(OperatingMode.AT);
 		
 		// Call the method under test.
-		wifiDevice.discoverAccessPoints();
+		wifiDevice.scanAccessPoints();
 	}
 	
 	/**
@@ -181,7 +181,7 @@ public class AccessPointsDiscoverTest {
 		PowerMockito.when(mockedAccessPoint.getSSID()).thenReturn("Dummy SSID");
 		accessPointsList.add(mockedAccessPoint);
 		
-		PowerMockito.doReturn(accessPointsList).when(wifiDevice, METHOD_DISCOVER_ACCESS_POINTS);
+		PowerMockito.doReturn(accessPointsList).when(wifiDevice, METHOD_SCAN_ACCESS_POINTS);
 		
 		// Call the method under test.
 		AccessPoint readAccessPoint = wifiDevice.getAccessPoint("Test SSID");
@@ -189,7 +189,7 @@ public class AccessPointsDiscoverTest {
 		// Verify the result.
 		assertThat("The discovered access point should be null", readAccessPoint, is(equalTo(null)));
 		
-		Mockito.verify(wifiDevice, Mockito.times(1)).discoverAccessPoints();
+		Mockito.verify(wifiDevice, Mockito.times(1)).scanAccessPoints();
 	}
 	
 	/**
@@ -216,7 +216,7 @@ public class AccessPointsDiscoverTest {
 		PowerMockito.when(mockedAccessPoint2.getSSID()).thenReturn(testSSID);
 		accessPointsList.add(mockedAccessPoint2);
 		
-		PowerMockito.doReturn(accessPointsList).when(wifiDevice, METHOD_DISCOVER_ACCESS_POINTS);
+		PowerMockito.doReturn(accessPointsList).when(wifiDevice, METHOD_SCAN_ACCESS_POINTS);
 		
 		// Call the method under test.
 		AccessPoint readAccessPoint = wifiDevice.getAccessPoint(testSSID);
@@ -225,19 +225,19 @@ public class AccessPointsDiscoverTest {
 		assertThat("The discovered access point shouldn't be null", readAccessPoint, is(IsNull.notNullValue()));
 		assertThat("The discovered access point's SSID should match the provided one", readAccessPoint.getSSID(), is(equalTo(testSSID)));
 		
-		Mockito.verify(wifiDevice, Mockito.times(1)).discoverAccessPoints();
+		Mockito.verify(wifiDevice, Mockito.times(1)).scanAccessPoints();
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#scanAccessPoints()}.
 	 * 
-	 * <p>Verify that {@code discoverAccessPoints()} method throws an {@code XBeeException} 
+	 * <p>Verify that {@code scanAccessPoints()} method throws an {@code XBeeException} 
 	 * if the device is already connected (AS response status is ERROR).</p>
 	 * 
 	 * @throws Exception 
 	 */
 	@Test(expected=XBeeException.class)
-	public final void testDiscoverAccessPointsErrorConnected() throws Exception {
+	public final void testScanAccessPointsErrorConnected() throws Exception {
 		// Setup the resources for the test.
 		asAnswers.clear();
 		asAnswers.add(new ATCommandResponsePacket(1, ATCommandStatus.ERROR, "AS", null));
@@ -259,19 +259,19 @@ public class AccessPointsDiscoverTest {
 		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
 		
 		// Call the method under test.
-		wifiDevice.discoverAccessPoints();
+		wifiDevice.scanAccessPoints();
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#scanAccessPoints()}.
 	 * 
-	 * <p>Verify that {@code discoverAccessPoints()} method throws a {@code TimeoutException} 
+	 * <p>Verify that {@code scanAccessPoints()} method throws a {@code TimeoutException} 
 	 * if it does not receive the end of discovery command after the configured timeout expires.</p>
 	 * 
 	 * @throws Exception 
 	 */
 	@Test(expected=TimeoutException.class)
-	public final void testDiscoverAccessPointsErrorTimeout() throws Exception {
+	public final void testScanAccessPointsErrorTimeout() throws Exception {
 		// Setup the resources for the test.
 		asAnswers.clear();
 		
@@ -293,19 +293,19 @@ public class AccessPointsDiscoverTest {
 		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
 		
 		// Call the method under test.
-		wifiDevice.discoverAccessPoints();
+		wifiDevice.scanAccessPoints();
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#scanAccessPoints()}.
 	 * 
-	 * <p>Verify that {@code discoverAccessPoints()} method returns an empty list of 
+	 * <p>Verify that {@code scanAccessPoints()} method returns an empty list of 
 	 * access points if only the end answer to AS command is received.</p>
 	 * 
 	 * @throws Exception 
 	 */
 	@Test
-	public final void testDiscoverAccessPointsSuccessEmpty() throws Exception {
+	public final void testScanAccessPointsSuccessEmpty() throws Exception {
 		// Setup the resources for the test.
 		asAnswers.clear();
 		
@@ -330,23 +330,23 @@ public class AccessPointsDiscoverTest {
 		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
 		
 		// Call the method under test.
-		List<AccessPoint> accessPointsList = wifiDevice.discoverAccessPoints();
+		List<AccessPoint> accessPointsList = wifiDevice.scanAccessPoints();
 		
 		// Verify the result.
 		assertThat("List of access points should be empty", accessPointsList.size(), is(equalTo(0)));
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#scanAccessPoints()}.
 	 * 
-	 * <p>Verify that {@code discoverAccessPoints()} method returns an empty list of 
+	 * <p>Verify that {@code scanAccessPoints()} method returns an empty list of 
 	 * access points if only the end answer to AS command is received. In this case the 
 	 * end answer has an empty (not null) parameter value.</p>
 	 * 
 	 * @throws Exception 
 	 */
 	@Test
-	public final void testDiscoverAccessPointsSuccessEmptyValueEmpty() throws Exception {
+	public final void testScanAccessPointsSuccessEmptyValueEmpty() throws Exception {
 		// Setup the resources for the test.
 		asAnswers.clear();
 		
@@ -371,22 +371,22 @@ public class AccessPointsDiscoverTest {
 		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
 		
 		// Call the method under test.
-		List<AccessPoint> accessPointsList = wifiDevice.discoverAccessPoints();
+		List<AccessPoint> accessPointsList = wifiDevice.scanAccessPoints();
 		
 		// Verify the result.
 		assertThat("List of access points should be empty", accessPointsList.size(), is(equalTo(0)));
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#discoverAccessPoints()}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#scanAccessPoints()}.
 	 * 
-	 * <p>Verify that {@code discoverAccessPoints()} method returns a list with
+	 * <p>Verify that {@code scanAccessPoints()} method returns a list with
 	 * discovered access points.</p>
 	 * 
 	 * @throws Exception 
 	 */
 	@Test
-	public final void testDiscoverAccessPointsSuccess() throws Exception {
+	public final void testScanAccessPointsSuccess() throws Exception {
 		// Setup the resources for the test.
 		asAnswers.clear();
 		
@@ -427,7 +427,7 @@ public class AccessPointsDiscoverTest {
 		}).when(wifiDevice, METHOD_SLEEP, Mockito.anyInt());
 		
 		// Call the method under test.
-		List<AccessPoint> accessPointsList = wifiDevice.discoverAccessPoints();
+		List<AccessPoint> accessPointsList = wifiDevice.scanAccessPoints();
 		
 		// Verify the result.
 		assertThat("List of access points should contain 2 access points", accessPointsList.size(), is(equalTo(2)));

--- a/library/src/test/java/com/digi/xbee/api/ConnectToAccessPointTest.java
+++ b/library/src/test/java/com/digi/xbee/api/ConnectToAccessPointTest.java
@@ -132,7 +132,7 @@ public class ConnectToAccessPointTest {
 		currentMillis = System.currentTimeMillis();
 		
 		// Configure the number of ticks (times) the sleep method should be called.
-		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		int ticks = wifiDevice.getAccessPointTimeout()/100;
 		
 		// Prepare the System class to return our fixed currentMillis variable when requested.
 		PowerMockito.mockStatic(System.class);
@@ -175,7 +175,7 @@ public class ConnectToAccessPointTest {
 		currentMillis = System.currentTimeMillis();
 		
 		// Configure the number of ticks (times) the sleep method should be called.
-		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		int ticks = wifiDevice.getAccessPointTimeout()/100;
 		
 		// Prepare the System class to return our fixed currentMillis variable when requested.
 		PowerMockito.mockStatic(System.class);
@@ -219,7 +219,7 @@ public class ConnectToAccessPointTest {
 		currentMillis = System.currentTimeMillis();
 		
 		// Configure the number of ticks (times) the sleep method should be called.
-		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		int ticks = wifiDevice.getAccessPointTimeout()/100;
 		
 		// Prepare the System class to return our fixed currentMillis variable when requested.
 		PowerMockito.mockStatic(System.class);
@@ -439,7 +439,7 @@ public class ConnectToAccessPointTest {
 		currentMillis = System.currentTimeMillis();
 		
 		// Configure the number of ticks (times) the sleep method should be called.
-		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		int ticks = wifiDevice.getAccessPointTimeout()/100;
 		
 		// Prepare the System class to return our fixed currentMillis variable when requested.
 		PowerMockito.mockStatic(System.class);
@@ -483,7 +483,7 @@ public class ConnectToAccessPointTest {
 		currentMillis = System.currentTimeMillis();
 		
 		// Configure the number of ticks (times) the sleep method should be called.
-		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		int ticks = wifiDevice.getAccessPointTimeout()/100;
 		
 		// Prepare the System class to return our fixed currentMillis variable when requested.
 		PowerMockito.mockStatic(System.class);
@@ -529,7 +529,7 @@ public class ConnectToAccessPointTest {
 		currentMillis = System.currentTimeMillis();
 		
 		// Configure the number of ticks (times) the sleep method should be called.
-		int ticks = wifiDevice.getWiFiReceiveTimeout()/100;
+		int ticks = wifiDevice.getAccessPointTimeout()/100;
 		
 		// Prepare the System class to return our fixed currentMillis variable when requested.
 		PowerMockito.mockStatic(System.class);

--- a/library/src/test/java/com/digi/xbee/api/WiFiDeviceTest.java
+++ b/library/src/test/java/com/digi/xbee/api/WiFiDeviceTest.java
@@ -197,33 +197,33 @@ public class WiFiDeviceTest {
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#setWiFiReceiveTimeout(int)}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#setAccessPointTimeout(int)}.
 	 * 
-	 * <p>Check that the Wi-Fi receive timeout cannot be set if it is negative throwing an 
+	 * <p>Check that the access point timeout cannot be set if it is negative throwing an 
 	 * {@code IllegalArgumentException}.</p>
 	 */
 	@Test(expected=IllegalArgumentException.class)
-	public void testSetWiFiReceiveTimeoutNegative() {
+	public void testSetAccessPointTimeoutNegative() {
 		// Call the method under test.
-		wifiDevice.setWiFiReceiveTimeout(-50);
+		wifiDevice.setAccessPointTimeout(-50);
 	}
 	
 	/**
-	 * Test method for {@link com.digi.xbee.api.WiFiDevice#setWiFiReceiveTimeout(int)} and 
-	 * {@link com.digi.xbee.api.WiFiDevice#getWiFiReceiveTimeout()}.
+	 * Test method for {@link com.digi.xbee.api.WiFiDevice#setAccessPointTimeout(int)} and 
+	 * {@link com.digi.xbee.api.WiFiDevice#getAccessPointTimeout()}.
 	 * 
-	 * <p>Check that the Wi-Fi receive timeout can be set and get successfully.</p>
+	 * <p>Check that the access point timeout can be set and get successfully.</p>
 	 */
 	@Test
-	public void testSetWiFiReceiveTimeoutSuccess() {
+	public void testSetAccessPointTimeoutSuccess() {
 		// First, verify that the timeout has the default value before changing it. 
-		assertEquals(15000, wifiDevice.getWiFiReceiveTimeout());
+		assertEquals(15000, wifiDevice.getAccessPointTimeout());
 		
 		// Call the method under test (change the timeout).
-		wifiDevice.setWiFiReceiveTimeout(5000);
+		wifiDevice.setAccessPointTimeout(5000);
 		
 		// First, verify that the new valu was set. 
-		assertEquals(5000, wifiDevice.getWiFiReceiveTimeout());
+		assertEquals(5000, wifiDevice.getAccessPointTimeout());
 	}
 	
 	 /**


### PR DESCRIPTION
- Renamed "discoverAccessPoints" method to "scanAccessPoints".
- Renamed the "Wi-Fi receive timeout" to "access point timeout" and updated
  the method names.
- Updated references and tests.

https://jira.digi.com/browse/XBJAPI-357
https://jira.digi.com/browse/XBJAPI-358

Signed-off-by: Diego Escalona <diego.escalona@digi.com>