### PR TITLE
pom.xml: configure the pom.xml files for publishing to Maven Central

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -4,7 +4,7 @@
 	
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>..\pom.xml</relativePath>
 	</parent>
@@ -18,11 +18,11 @@
 	<dependencies>
 		<!-- NOTE: These dependency declaration is only required to sort this 
 		project to the end of the line in the multimodule build. Since we only 
-		include the xbjlib module in our assembly, we only need to ensure this 
-		distribution project builds AFTER that one... -->
+		include the xbee-java-library module in our assembly, we only need to 
+		ensure this distribution project builds AFTER that one... -->
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>
@@ -74,7 +74,16 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
-	
 </project>

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -57,7 +57,7 @@
 		<!-- Include the XBee Java Library jar -->
 		<dependencySet>
 			<includes>
-				<include>com.digi.xbee:xbjlib:jar:*</include>
+				<include>com.digi.xbee:xbee-java-library:jar:*</include>
 			</includes>
 			<outputDirectory>/</outputDirectory>
 			<useProjectArtifact>false</useProjectArtifact>
@@ -67,7 +67,7 @@
 		<dependencySet>
 			<excludes>
 				<exclude>org.rxtx:rxtx-native:jar:*</exclude>
-				<exclude>com.digi.xbee:xbjlib:jar:*</exclude>
+				<exclude>com.digi.xbee:xbee-java-library:jar:*</exclude>
 			</excludes>
 			<outputDirectory>extra-libs</outputDirectory>
 			<useProjectArtifact>false</useProjectArtifact>

--- a/examples/communication/ReceiveDataPollingSample/pom.xml
+++ b/examples/communication/ReceiveDataPollingSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/ReceiveDataSample/pom.xml
+++ b/examples/communication/ReceiveDataSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/ReceiveModemStatusSample/pom.xml
+++ b/examples/communication/ReceiveModemStatusSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/SendBroadcastDataSample/pom.xml
+++ b/examples/communication/SendBroadcastDataSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/SendDataAsyncSample/pom.xml
+++ b/examples/communication/SendDataAsyncSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/SendDataSample/pom.xml
+++ b/examples/communication/SendDataSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/cellular/ReceiveSMSSample/pom.xml
+++ b/examples/communication/cellular/ReceiveSMSSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/cellular/SendSMSSample/pom.xml
+++ b/examples/communication/cellular/SendSMSSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/explicit/ReceiveExplicitDataPollingSample/pom.xml
+++ b/examples/communication/explicit/ReceiveExplicitDataPollingSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/explicit/ReceiveExplicitDataSample/pom.xml
+++ b/examples/communication/explicit/ReceiveExplicitDataSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/explicit/SendBroadcastExplicitDataSample/pom.xml
+++ b/examples/communication/explicit/SendBroadcastExplicitDataSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/explicit/SendExplicitDataAsyncSample/pom.xml
+++ b/examples/communication/explicit/SendExplicitDataAsyncSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/explicit/SendExplicitDataSample/pom.xml
+++ b/examples/communication/explicit/SendExplicitDataSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/ip/ConnectToEchoServerSample/pom.xml
+++ b/examples/communication/ip/ConnectToEchoServerSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/ip/KnockKnockSample/pom.xml
+++ b/examples/communication/ip/KnockKnockSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/ip/ReceiveIPDataSample/pom.xml
+++ b/examples/communication/ip/ReceiveIPDataSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/communication/ip/SendIPDataSample/pom.xml
+++ b/examples/communication/ip/SendIPDataSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/configuration/ConnectToAccessPointSample/pom.xml
+++ b/examples/configuration/ConnectToAccessPointSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/configuration/ManageCommonParametersSample/pom.xml
+++ b/examples/configuration/ManageCommonParametersSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/configuration/ResetModuleSample/pom.xml
+++ b/examples/configuration/ResetModuleSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/configuration/SetAndGetParametersSample/pom.xml
+++ b/examples/configuration/SetAndGetParametersSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/io/IOSamplingSample/pom.xml
+++ b/examples/io/IOSamplingSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/io/LocalADCSample/pom.xml
+++ b/examples/io/LocalADCSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/io/LocalDIOSample/pom.xml
+++ b/examples/io/LocalDIOSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/io/RemoteADCSample/pom.xml
+++ b/examples/io/RemoteADCSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/io/RemoteDIOSample/pom.xml
+++ b/examples/io/RemoteDIOSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/examples/network/DiscoverDevicesSample/pom.xml
+++ b/examples/network/DiscoverDevicesSample/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
@@ -36,13 +36,23 @@
 					</arguments>
 				</configuration>
 			</plugin>
+			<!-- This is needed to skip this submodule from staging -->
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>${nexus.staging.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.digi.xbee</groupId>
-			<artifactId>xbjlib</artifactId>
+			<artifactId>xbee-java-library</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 		</dependency>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -3,11 +3,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.digi.xbee</groupId>
-		<artifactId>xbjlib-parent</artifactId>
+		<artifactId>xbee-java-library-parent</artifactId>
 		<version>1.2.0</version>
 		<relativePath>..\pom.xml</relativePath>
 	</parent>
-	<artifactId>xbjlib</artifactId>
+	<artifactId>xbee-java-library</artifactId>
 	<packaging>jar</packaging>
 	
 	<name>XBee Java Library</name>
@@ -73,8 +73,8 @@
 					<source>1.7</source>
 					<version>true</version>
 					<docfilessubdirs>true</docfilessubdirs>
-					<!--<javadocDirectory>${basedir}/src/main/javadoc/</javadocDirectory>-->
-					<!--<overview>${basedir}/src/main/javadoc/overview.html</overview>-->
+					<javadocDirectory>${basedir}/src/main/javadoc/</javadocDirectory>
+					<overview>${basedir}/src/main/javadoc/overview.html</overview>
 					<stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
 					<windowtitle>${project.name}</windowtitle>
 					<doctitle>${project.name}</doctitle>
@@ -121,4 +121,30 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<!-- Sign profile -->
+		<profile>
+			<id>sign</id>
+			<build>
+				<plugins>
+					<!-- This is needed to sign the jar files for the 
+						 deployment in Maven Central -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>${maven.gpg.plugin.version}</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
 	<groupId>com.digi.xbee</groupId>
-	<artifactId>xbjlib-parent</artifactId>
+	<artifactId>xbee-java-library-parent</artifactId>
 	<version>1.2.0</version>
 	<packaging>pom</packaging>
 	<name>XBee Java Library Project</name>
 	<inceptionYear>2014</inceptionYear>
+	<description>Set of Java APIs to interact with Digi International's XBee radio frequency modules.</description>
 	<url>https://github.com/digidotcom/XBeeJavaLibrary</url>
+	
 	<organization>
 		<name>Digi International Inc.</name>
 		<url>http://www.digi.com</url>
 	</organization>
+	
 	<licenses>
 		<license>
 			<name>Mozilla Public License, Version 2.0</name>
@@ -19,6 +23,48 @@
 			<distribution>manual</distribution>
 		</license>
 	</licenses>
+	
+	<scm>
+		<url>https://github.com/digidotcom/XBeeJavaLibrary/tree/master</url>
+		<connection>scm:git:git://github.com/digidotcom/XBeeJavaLibrary.git</connection>
+		<developerConnection>scm:git:ssh://github.com:digidotcom/XBeeJavaLibrary.git</developerConnection>
+	</scm>
+	
+	<issueManagement>
+ 		<url>https://github.com/digidotcom/XBeeJavaLibrary/issues</url>
+		<system>GitHub</system>
+	</issueManagement>
+	
+	<developers>
+		<developer>
+			<id>rubenmoral</id>
+			<name>Rubén Moral</name>
+			<email>ruben.moral@digi.com</email>
+			<organization>Digi International Inc.</organization>
+			<organizationUrl>http://www.digi.com</organizationUrl>
+		</developer>
+		<developer>
+			<id>diescalo</id>
+			<name>Diego Escalona</name>
+			<email>diego.escalona@digi.com</email>
+			<organization>Digi International Inc.</organization>
+			<organizationUrl>http://www.digi.com</organizationUrl>
+		</developer>
+		<developer>
+			<id>daescalona</id>
+			<name>David Escalona</name>
+			<email>david.escalona@digi.com</email>
+			<organization>Digi International Inc.</organization>
+			<organizationUrl>http://www.digi.com</organizationUrl>
+		</developer>
+		<developer>
+			<id>tatianaleon</id>
+			<name>Tatiana León</name>
+			<email>tatiana.leon@digi.com</email>
+			<organization>Digi International Inc.</organization>
+			<organizationUrl>http://www.digi.com</organizationUrl>
+		</developer>
+	</developers>
 	
 	<modules>
 		<module>library</module>
@@ -60,6 +106,8 @@
 		<maven.jar.plugin.version>2.6</maven.jar.plugin.version>
 		<maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
 		<javadoc.plugin.version>2.10.3</javadoc.plugin.version>
+		<nexus.staging.maven.plugin.version>1.6.7</nexus.staging.maven.plugin.version>
+		<maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
 		<rxtx.version>2.2</rxtx.version>
 		<slf4j-api.version>1.7.12</slf4j-api.version>
 		<slf4j-jdk1.4.version>1.7.12</slf4j-jdk1.4.version>
@@ -77,6 +125,7 @@
 		<android-sdk-addon.version>3</android-sdk-addon.version>
 		<rxtx.native.libs.dir>rxtx-native-libs</rxtx.native.libs.dir>
 		<assemblyId>Release</assemblyId>
+		
 	</properties>
 	
 	<build>
@@ -125,10 +174,35 @@
 						</dependency>
 					</dependencies>
 				</plugin>
+				<!-- This is needed to stage the library for deployment
+					 in Maven Central -->
+				<plugin>
+					<groupId>org.sonatype.plugins</groupId>
+					<artifactId>nexus-staging-maven-plugin</artifactId>
+					<version>${nexus.staging.maven.plugin.version}</version>
+					<extensions>true</extensions>
+					<configuration>
+						<serverId>ossrh</serverId>
+						<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+						<autoReleaseAfterClose>false</autoReleaseAfterClose>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
 	
+	<!-- Distribution Management -->
+	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+	</distributionManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.rxtx</groupId>
@@ -270,6 +344,30 @@
 			</properties>
 		</profile>
 		
+		<!-- Sign profile -->
+		<profile>
+			<id>sign</id>
+			<build>
+				<plugins>
+					<!-- This is needed to sign the jar files for the 
+						 deployment in Maven Central -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>${maven.gpg.plugin.version}</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	
 	<!-- Repositories -->


### PR DESCRIPTION
- Added extra information to the parent pom.xml required for publishing.
- Configured the distribution and examples modules so that they are not
  published.
- Added the 'sign' profile used to sign the artifacts that are being
  published to Maven Central. This profile can be loaded with '-Psign' when
  executing the maven command.
- Renamed the artifact to 'xbee-java-library'.

Signed-off-by: Diego Escalona <diego.escalona@digi.com>