### PR TITLE
fix #53: check that 64-bit address is not unknown before obtaining the remote XBee device from the network

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/connection/DataReader.java
+++ b/library/src/main/java/com/digi/xbee/api/connection/DataReader.java
@@ -699,7 +699,10 @@ public class DataReader extends Thread {
 			ReceivePacket receivePacket = (ReceivePacket)apiPacket;
 			addr64 = receivePacket.get64bitSourceAddress();
 			addr16 = receivePacket.get16bitSourceAddress();
-			remoteDevice = network.getDevice(addr64);
+			if (addr64 != XBee64BitAddress.UNKNOWN_ADDRESS)
+				remoteDevice = network.getDevice(addr64);
+			else if (addr16 != XBee16BitAddress.UNKNOWN_ADDRESS)
+				remoteDevice = network.getDevice(addr16);
 			break;
 		case RX_64:
 			RX64Packet rx64Packet = (RX64Packet)apiPacket;
@@ -744,7 +747,8 @@ public class DataReader extends Thread {
 		// If the origin is not in the network, add it.
 		if (remoteDevice == null) {
 			remoteDevice = createRemoteXBeeDevice(addr64, addr16, null);
-			network.addRemoteDevice(remoteDevice);
+			if (addr64 != XBee64BitAddress.UNKNOWN_ADDRESS || addr16 != XBee16BitAddress.UNKNOWN_ADDRESS)
+				network.addRemoteDevice(remoteDevice);
 		}
 		
 		return remoteDevice;


### PR DESCRIPTION
https://github.com/digidotcom/XBeeJavaLibrary/issues/53

Signed-off-by: Ruben Moral <Ruben.Moral@digi.com>