### PR TITLE
fix #101: avoid reading the 16-bit address when the protocol is SX

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
@@ -477,11 +477,11 @@ public abstract class AbstractXBeeDevice {
 		// Get the 16-bit address. This must be done after obtaining the protocol because 
 		// DigiMesh and Point-to-Multipoint protocols don't have 16-bit addresses.
 		XBeeProtocol protocol = getXBeeProtocol();
-		if (protocol != XBeeProtocol.DIGI_MESH 
-				&& protocol != XBeeProtocol.DIGI_POINT
-				&& protocol != XBeeProtocol.XBEE_WIFI
-				&& protocol != XBeeProtocol.CELLULAR
-				&& protocol != XBeeProtocol.UNKNOWN) {
+		if (protocol == XBeeProtocol.ZIGBEE
+				|| protocol == XBeeProtocol.RAW_802_15_4
+				|| protocol == XBeeProtocol.XTEND
+				|| protocol == XBeeProtocol.SMART_ENERGY
+				|| protocol == XBeeProtocol.ZNET) {
 			response = getParameter("MY");
 			xbee16BitAddress = new XBee16BitAddress(response);
 		}

--- a/library/src/main/java/com/digi/xbee/api/NodeDiscovery.java
+++ b/library/src/main/java/com/digi/xbee/api/NodeDiscovery.java
@@ -482,6 +482,7 @@ class NodeDiscovery {
 		// TODO [XLR_DM] The next version of the XLR will add DigiMesh support.
 		// For the moment only point-to-multipoint is supported in this kind of devices.
 		case XLR_DM:
+		case SX:
 			// Read node identifier.
 			id = ByteUtils.readString(inputStream);
 			// Read parent address.


### PR DESCRIPTION
It also fixes the node discovery of remote SX devices.

Signed-off-by: Ruben Moral <Ruben.Moral@digi.com>