### PR TITLE
cellular: add support for new hardware versions

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/models/HardwareVersionEnum.java
+++ b/library/src/main/java/com/digi/xbee/api/models/HardwareVersionEnum.java
@@ -78,8 +78,20 @@ public enum HardwareVersionEnum {
 	S2D_TH_REG(0x35, "XB24D: S2D TH Reg"),
 	SX(0x3E, "SX"),
 	XTR(0x3F, "XTR"),
-	/** @since 1.2.0 */
-	CELLULAR(0x40, "CELLULAR");
+	/** 
+	 * @deprecated Use {@link #CELLULAR_CAT1_LTE_VERIZON} instead.
+	 * @since 1.2.0 */
+	CELLULAR(0x40, "CELLULAR"),
+	/** @since 1.2.1 */
+	CELLULAR_CAT1_LTE_VERIZON(0x40, "XBee Cellular Cat 1 LTE Verizon"),
+	/** @since 1.2.1 */
+	CELLULAR_3G(0x44, "XBee Cellular 3G"),
+	/** @since 1.2.1 */
+	CELLULAR_LTE_VERIZON(0x46, "XBee Cellular LTE-M Verizon"),
+	/** @since 1.2.1 */
+	CELLULAR_LTE_ATT(0x47, "XBee Cellular LTE-M AT&T"),
+	/** @since 1.2.1 */
+	CELLULAR_NBIOT_EUROPE(0x48, "XBee Cellular NBIoT Europe");
 	
 	// Variables
 	private final int value;

--- a/library/src/main/java/com/digi/xbee/api/models/XBeeProtocol.java
+++ b/library/src/main/java/com/digi/xbee/api/models/XBeeProtocol.java
@@ -112,6 +112,7 @@ public enum XBeeProtocol {
 	 * 
 	 * @see HardwareVersion
 	 */
+	@SuppressWarnings("deprecation")
 	public static XBeeProtocol determineProtocol(HardwareVersion hardwareVersion, String firmwareVersion) {
 		if (hardwareVersion == null || firmwareVersion == null || hardwareVersion.getValue() < 0x09 
 				|| HardwareVersionEnum.get(hardwareVersion.getValue()) == null)
@@ -225,6 +226,10 @@ public enum XBeeProtocol {
 		case S2D_TH_REG:
 			return ZIGBEE;
 		case CELLULAR:
+		case CELLULAR_3G:
+		case CELLULAR_LTE_VERIZON:
+		case CELLULAR_LTE_ATT:
+		case CELLULAR_NBIOT_EUROPE:
 			return CELLULAR;
 		default:
 			return ZIGBEE;

--- a/library/src/test/java/com/digi/xbee/api/models/HardwareVersionEnumTest.java
+++ b/library/src/test/java/com/digi/xbee/api/models/HardwareVersionEnumTest.java
@@ -77,7 +77,11 @@ public class HardwareVersionEnumTest {
 	 */
 	@Test
 	public void testHardwareVersionEnumStaticAccess() {
-		for (HardwareVersionEnum hardwareVersionEnum:hardwareVersionValues)
+		for (HardwareVersionEnum hardwareVersionEnum:hardwareVersionValues) {
+			// Do not check deprecated entry.
+			if (hardwareVersionEnum == HardwareVersionEnum.CELLULAR)
+				continue;
 			assertEquals(hardwareVersionEnum, HardwareVersionEnum.get(hardwareVersionEnum.getValue()));
+		}
 	}
 }


### PR DESCRIPTION
- Added support for 3G, LTE Verizon, LTE ATT and NB-IoT.

Signed-off-by: Héctor González <hector.gonzalez@digi.com>