### PR TITLE
packets: increase the upper limit of the packet RSSI value from 100 to 255

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/packet/raw/RX16IOPacket.java
+++ b/library/src/main/java/com/digi/xbee/api/packet/raw/RX16IOPacket.java
@@ -68,7 +68,7 @@ public class RX16IOPacket extends XBeeAPIPacket {
 	 * @throws IllegalArgumentException if {@code payload[0] != APIFrameType.RX_16.getValue()} or
 	 *                                  if {@code payload.length < }{@value #MIN_API_PAYLOAD_LENGTH} or
 	 *                                  if {@code rssi < 0} or
-	 *                                  if {@code rssi > 100} or
+	 *                                  if {@code rssi > 255} or
 	 *                                  if {@code receiveOptions < 0} or
 	 *                                  if {@code receiveOptions > 255}.
 	 * @throws NullPointerException if {@code payload == null}.
@@ -117,7 +117,7 @@ public class RX16IOPacket extends XBeeAPIPacket {
 	 * @param rfData Received RF data.
 	 * 
 	 * @throws IllegalArgumentException if {@code rssi < 0} or
-	 *                                  if {@code rssi > 100} or
+	 *                                  if {@code rssi > 255} or
 	 *                                  if {@code receiveOptions < 0} or
 	 *                                  if {@code receiveOptions > 255}.
 	 * @throws NullPointerException if {@code sourceAddress16 == null}.
@@ -130,8 +130,8 @@ public class RX16IOPacket extends XBeeAPIPacket {
 		
 		if (sourceAddress16 == null)
 			throw new NullPointerException("16-bit source address cannot be null.");
-		if (rssi < 0 || rssi > 100)
-			throw new IllegalArgumentException("RSSI value must be between 0 and 100.");
+		if (rssi < 0 || rssi > 255)
+			throw new IllegalArgumentException("RSSI value must be between 0 and 255.");
 		if (receiveOptions < 0 || receiveOptions > 255)
 			throw new IllegalArgumentException("Receive options value must be between 0 and 255.");
 		

--- a/library/src/main/java/com/digi/xbee/api/packet/raw/RX16Packet.java
+++ b/library/src/main/java/com/digi/xbee/api/packet/raw/RX16Packet.java
@@ -69,7 +69,7 @@ public class RX16Packet extends XBeeAPIPacket {
 	 * @throws IllegalArgumentException if {@code payload[0] != APIFrameType.RX_16.getValue()} or
 	 *                                  if {@code payload.length < }{@value #MIN_API_PAYLOAD_LENGTH} or
 	 *                                  if {@code rssi < 0} or
-	 *                                  if {@code rssi > 100} or
+	 *                                  if {@code rssi > 255} or
 	 *                                  if {@code receiveOptions < 0} or
 	 *                                  if {@code receiveOptions > 255}.
 	 * @throws NullPointerException if {@code payload == null}.
@@ -118,7 +118,7 @@ public class RX16Packet extends XBeeAPIPacket {
 	 * @param rfData Received RF data.
 	 * 
 	 * @throws IllegalArgumentException if {@code rssi < 0} or
-	 *                                  if {@code rssi > 100} or
+	 *                                  if {@code rssi > 255} or
 	 *                                  if {@code receiveOptions < 0} or
 	 *                                  if {@code receiveOptions > 255}.
 	 * @throws NullPointerException if {@code sourceAddress16 == null}.
@@ -131,8 +131,8 @@ public class RX16Packet extends XBeeAPIPacket {
 		
 		if (sourceAddress16 == null)
 			throw new NullPointerException("16-bit source address cannot be null.");
-		if (rssi < 0 || rssi > 100)
-			throw new IllegalArgumentException("RSSI value must be between 0 and 100.");
+		if (rssi < 0 || rssi > 255)
+			throw new IllegalArgumentException("RSSI value must be between 0 and 255.");
 		if (receiveOptions < 0 || receiveOptions > 255)
 			throw new IllegalArgumentException("Receive options value must be between 0 and 255.");
 		

--- a/library/src/main/java/com/digi/xbee/api/packet/raw/RX64IOPacket.java
+++ b/library/src/main/java/com/digi/xbee/api/packet/raw/RX64IOPacket.java
@@ -68,7 +68,7 @@ public class RX64IOPacket extends XBeeAPIPacket {
 	 * @throws IllegalArgumentException if {@code payload[0] != APIFrameType.RX_64.getValue()} or
 	 *                                  if {@code payload.length < }{@value #MIN_API_PAYLOAD_LENGTH} or
 	 *                                  if {@code rssi < 0} or
-	 *                                  if {@code rssi > 100} or
+	 *                                  if {@code rssi > 255} or
 	 *                                  if {@code receiveOptions < 0} or
 	 *                                  if {@code receiveOptions > 255}.
 	 * @throws NullPointerException if {@code payload == null}.
@@ -117,7 +117,7 @@ public class RX64IOPacket extends XBeeAPIPacket {
 	 * @param rfData Received RF data.
 	 * 
 	 * @throws IllegalArgumentException if {@code rssi < 0} or
-	 *                                  if {@code rssi > 100} or
+	 *                                  if {@code rssi > 255} or
 	 *                                  if {@code receiveOptions < 0} or
 	 *                                  if {@code receiveOptions > 255}.
 	 * @throws NullPointerException if {@code sourceAddress64 == null}.
@@ -130,8 +130,8 @@ public class RX64IOPacket extends XBeeAPIPacket {
 		
 		if (sourceAddress64 == null)
 			throw new NullPointerException("64-bit source address cannot be null.");
-		if (rssi < 0 || rssi > 100)
-			throw new IllegalArgumentException("RSSI value must be between 0 and 100.");
+		if (rssi < 0 || rssi > 255)
+			throw new IllegalArgumentException("RSSI value must be between 0 and 255.");
 		if (receiveOptions < 0 || receiveOptions > 255)
 			throw new IllegalArgumentException("Receive options value must be between 0 and 255.");
 		

--- a/library/src/main/java/com/digi/xbee/api/packet/raw/RX64Packet.java
+++ b/library/src/main/java/com/digi/xbee/api/packet/raw/RX64Packet.java
@@ -69,7 +69,7 @@ public class RX64Packet extends XBeeAPIPacket {
 	 * @throws IllegalArgumentException if {@code payload[0] != APIFrameType.RX_64.getValue()} or
 	 *                                  if {@code payload.length < }{@value #MIN_API_PAYLOAD_LENGTH} or
 	 *                                  if {@code rssi < 0} or
-	 *                                  if {@code rssi > 100} or
+	 *                                  if {@code rssi > 255} or
 	 *                                  if {@code receiveOptions < 0} or
 	 *                                  if {@code receiveOptions > 255}.
 	 * @throws NullPointerException if {@code payload == null}.
@@ -118,7 +118,7 @@ public class RX64Packet extends XBeeAPIPacket {
 	 * @param rfData Received RF data.
 	 * 
 	 * @throws IllegalArgumentException if {@code rssi < 0} or
-	 *                                  if {@code rssi > 100} or
+	 *                                  if {@code rssi > 255} or
 	 *                                  if {@code receiveOptions < 0} or
 	 *                                  if {@code receiveOptions > 255}.
 	 * @throws NullPointerException if {@code sourceAddress64 == null}.
@@ -131,8 +131,8 @@ public class RX64Packet extends XBeeAPIPacket {
 		
 		if (sourceAddress64 == null)
 			throw new NullPointerException("64-bit source address cannot be null.");
-		if (rssi < 0 || rssi > 100)
-			throw new IllegalArgumentException("RSSI value must be between 0 and 100.");
+		if (rssi < 0 || rssi > 255)
+			throw new IllegalArgumentException("RSSI value must be between 0 and 255.");
 		if (receiveOptions < 0 || receiveOptions > 255)
 			throw new IllegalArgumentException("Receive options value must be between 0 and 255.");
 		

--- a/library/src/test/java/com/digi/xbee/api/packet/raw/RX16IOPacketTest.java
+++ b/library/src/test/java/com/digi/xbee/api/packet/raw/RX16IOPacketTest.java
@@ -327,19 +327,19 @@ public class RX16IOPacketTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.packet.raw.RX16IOPacket#RX16IOPacket(XBee16BitAddress, int, int, byte[])}.
 	 * 
-	 * <p>Construct a new RX16 IO packet but with a RSSI bigger than 100. 
+	 * <p>Construct a new RX16 IO packet but with a RSSI bigger than 255. 
 	 * This must throw an {@code IllegalArgumentException}.</p>
 	 */
 	@Test
-	public final void testCreateRX16IOPacketRssiBiggerThan100() {
+	public final void testCreateRX16IOPacketRssiBiggerThan255() {
 		// Setup the resources for the test.
 		XBee16BitAddress source16Addr = new XBee16BitAddress("D817");
-		int rssi = 725;
+		int rssi = 256;
 		int options = 40;
 		byte[] data = new byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
 		
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 100.")));
+		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 255.")));
 		
 		// Call the method under test that should throw a NullPointerException.
 		new RX16IOPacket(source16Addr, rssi, options, data);
@@ -360,7 +360,7 @@ public class RX16IOPacketTest {
 		byte[] data = new byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
 		
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 100.")));
+		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 255.")));
 		
 		// Call the method under test that should throw a NullPointerException.
 		new RX16IOPacket(source16Addr, rssi, options, data);

--- a/library/src/test/java/com/digi/xbee/api/packet/raw/RX16PacketTest.java
+++ b/library/src/test/java/com/digi/xbee/api/packet/raw/RX16PacketTest.java
@@ -251,19 +251,19 @@ public class RX16PacketTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.packet.raw.RX16Packet#RX16Packet(XBee16BitAddress, int, int, byte[])}.
 	 * 
-	 * <p>Construct a new RX16 packet but with a RSSI bigger than 100. 
+	 * <p>Construct a new RX16 packet but with a RSSI bigger than 255. 
 	 * This must throw an {@code IllegalArgumentException}.</p>
 	 */
 	@Test
-	public final void testCreateRX16PacketRssiBiggerThan100() {
+	public final void testCreateRX16PacketRssiBiggerThan255() {
 		// Setup the resources for the test.
 		XBee16BitAddress source16Addr = new XBee16BitAddress("D817");
-		int rssi = 725;
+		int rssi = 256;
 		int options = 40;
 		byte[] data = new byte[]{0x68, 0x6F, 0x6C, 0x61};
 		
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 100.")));
+		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 255.")));
 		
 		// Call the method under test that should throw a NullPointerException.
 		new RX16Packet(source16Addr, rssi, options, data);
@@ -284,7 +284,7 @@ public class RX16PacketTest {
 		byte[] data = new byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
 		
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 100.")));
+		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 255.")));
 		
 		// Call the method under test that should throw a NullPointerException.
 		new RX16Packet(source16Addr, rssi, options, data);

--- a/library/src/test/java/com/digi/xbee/api/packet/raw/RX64IOPacketTest.java
+++ b/library/src/test/java/com/digi/xbee/api/packet/raw/RX64IOPacketTest.java
@@ -330,19 +330,19 @@ public class RX64IOPacketTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.packet.raw.RX64IOPacket#RX64IOPacket(XBee64BitAddress, int, int, byte[])}.
 	 * 
-	 * <p>Construct a new RX64 IO packet but with a RSSI bigger than 100. 
+	 * <p>Construct a new RX64 IO packet but with a RSSI bigger than 255. 
 	 * This must throw an {@code IllegalArgumentException}.</p>
 	 */
 	@Test
-	public final void testCreateRX64IOPacketRssiBiggerThan100() {
+	public final void testCreateRX64IOPacketRssiBiggerThan255() {
 		// Setup the resources for the test.
 		XBee64BitAddress source64Addr = new XBee64BitAddress("0013A2004032D9AB");
-		int rssi = 725;
+		int rssi = 256;
 		int options = 40;
 		byte[] data = new byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
 		
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 100.")));
+		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 255.")));
 		
 		// Call the method under test that should throw a NullPointerException.
 		new RX64IOPacket(source64Addr, rssi, options, data);
@@ -363,7 +363,7 @@ public class RX64IOPacketTest {
 		byte[] data = new byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
 		
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 100.")));
+		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 255.")));
 		
 		// Call the method under test that should throw a NullPointerException.
 		new RX64IOPacket(source64Addr, rssi, options, data);

--- a/library/src/test/java/com/digi/xbee/api/packet/raw/RX64PacketTest.java
+++ b/library/src/test/java/com/digi/xbee/api/packet/raw/RX64PacketTest.java
@@ -251,19 +251,19 @@ public class RX64PacketTest {
 	/**
 	 * Test method for {@link com.digi.xbee.api.packet.raw.RX64Packet#RX64Packet(XBee64BitAddress, int, int, byte[])}.
 	 * 
-	 * <p>Construct a new RX64 packet but with a RSSI bigger than 100. 
+	 * <p>Construct a new RX64 packet but with a RSSI bigger than 255. 
 	 * This must throw an {@code IllegalArgumentException}.</p>
 	 */
 	@Test
-	public final void testCreateRX64PacketRssiBiggerThan100() {
+	public final void testCreateRX64PacketRssiBiggerThan255() {
 		// Setup the resources for the test.
 		XBee64BitAddress source64Addr = new XBee64BitAddress("0013A2004032D9AB");
-		int rssi = 725;
+		int rssi = 256;
 		int options = 40;
 		byte[] data = new byte[]{0x68, 0x6F, 0x6C, 0x61};
 		
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 100.")));
+		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 255.")));
 		
 		// Call the method under test that should throw a NullPointerException.
 		new RX64Packet(source64Addr, rssi, options, data);
@@ -284,7 +284,7 @@ public class RX64PacketTest {
 		byte[] data = new byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
 		
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 100.")));
+		exception.expectMessage(is(equalTo("RSSI value must be between 0 and 255.")));
 		
 		// Call the method under test that should throw a NullPointerException.
 		new RX64Packet(source64Addr, rssi, options, data);


### PR DESCRIPTION
This was causing the library to throw an exception when the local module
received data packets from remotes that were too far.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>