### PR TITLE
abstract: synchronize method to get next frame ID to avoid multiple threads to increment the counter at the same time

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
+++ b/library/src/main/java/com/digi/xbee/api/AbstractXBeeDevice.java
@@ -1460,7 +1460,7 @@ public abstract class AbstractXBeeDevice {
 	 * 
 	 * @return The next Frame ID.
 	 */
-	protected int getNextFrameID() {
+	protected synchronized int getNextFrameID() {
 		if (isRemote())
 			return localXBeeDevice.getNextFrameID();
 		if (currentFrameID == 0xff) {


### PR DESCRIPTION
This could fix an issue of a customer getting sometimes an
IllegalArgumentException when sending data (#130).

Signed-off-by: Ruben Moral <ruben.moral@digi.com>